### PR TITLE
TEAMNADO-7122: Messaging should provide clarification re: activation keys

### DIFF
--- a/src/Components/Authentication/Authentication.js
+++ b/src/Components/Authentication/Authentication.js
@@ -35,7 +35,7 @@ const Authentication = ({ children }) => {
   } else if (isLoading === true || isFetching === true) {
     return <Loading />;
   } else if (isSuccess === true && !hasAnyPermission) {
-    return <NotAuthorized serviceName="Remote Host Configuration" />;
+    return <NotAuthorized serviceName="Activation Keys" />;
   } else if (isSuccess === true) {
     return <>{children}</>;
   } else {

--- a/src/Components/Authentication/__tests__/__snapshots__/Authentication.test.js.snap
+++ b/src/Components/Authentication/__tests__/__snapshots__/Authentication.test.js.snap
@@ -34,7 +34,7 @@ exports[`Authentication when user has no permissions renders the NotAuthorized 1
           <h5
             class="pf-v5-c-empty-state__title-text"
           >
-            You do not have access to Remote Host Configuration
+            You do not have access to Activation Keys
           </h5>
         </div>
       </div>


### PR DESCRIPTION
This fixes a reported bug where users lacking access to Activation Keys were shown a message stating they don't have access to RHC. This was due to using a shared component from RHC without updating the app name to Activation Keys.

This also updates the Authentication test snapshot to reflect the new application name so that tests pass as expected.