### PR TITLE
TUSC-1: Check existing activation key names when creating a new one

### DIFF
--- a/src/Components/Modals/CreateActivationKeyWizard.js
+++ b/src/Components/Modals/CreateActivationKeyWizard.js
@@ -12,6 +12,7 @@ import SetNamePage from '../Pages/SetNamePage';
 import SetWorkloadPage from '../Pages/SetWorkLoadPage';
 import SetSystemPurposePage from '../Pages/SetSystemPurposePage';
 import SuccessPage from '../Pages/SuccessPage';
+import useActivationKeys from '../../hooks/useActivationKeys';
 
 const workloadOptions = ['Latest release', 'Extended support releases'];
 const confirmCloseTitle = 'Exit activation key creation?';
@@ -27,9 +28,16 @@ const ConfirmCloseFooter = ({ onClose, returnToWizard }) => (
   </>
 );
 
-const nameValidator = /^([\w-_])+$/;
+const nameRegex = /^([\w-_])+$/;
+const nameValidator = (newName, keyNames) => {
+  const match = keyNames?.find(name => {
+    return name == newName;
+  }) || [];
 
-const CreateActivationKeyWizard = ({ handleModalToggle, isOpen }) => {
+  return match.length == 0 && nameRegex.test(newName);
+}
+
+const CreateActivationKeyWizard = ({ handleModalToggle, isOpen}) => {
   const queryClient = useQueryClient();
   const { mutate, isLoading: createActivationKeyIsLoading } =
     useCreateActivationKey();
@@ -38,6 +46,7 @@ const CreateActivationKeyWizard = ({ handleModalToggle, isOpen }) => {
     error,
     data,
   } = useSystemPurposeAttributes();
+  const { data: activationKeys } = useActivationKeys();
   const { addSuccessNotification, addErrorNotification } = useNotifications();
   const [name, setName] = useState('');
   const [workload, setWorkload] = useState(workloadOptions[0]);
@@ -51,8 +60,9 @@ const CreateActivationKeyWizard = ({ handleModalToggle, isOpen }) => {
   const [isConfirmClose, setIsConfirmClose] = useState(false);
   const [shouldConfirmClose, setShouldConfirmClose] = useState(false);
   const [currentStep, setCurrentStep] = useState(0);
+  const keyNames = activationKeys?.map(key => key.name) || []
 
-  const nameIsValid = nameValidator.test(name);
+  const nameIsValid = nameValidator(name, keyNames);
 
   const onClose = () => {
     queryClient.invalidateQueries(['activation_keys']);


### PR DESCRIPTION
This adds a check for existing activation key names to the create modal, so that a user cannot attempt to create a key with a name that is already used. It uses the activation keys hook, instead of passing a prop to the modal because this is a federated module, and may need to find its own information from somewhere else.

I've tested this filtering with 100,000 activation keys, and the validation is still instant, so I am not worried about performance of checking every key on each keystroke.