### PR TITLE
Export CreateActivationKeyWizard with context

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -28,7 +28,7 @@ module.exports = {
       './RootApp': resolve(__dirname, './src/AppEntry'),
       './CreateActivationKeyWizard': resolve(
         __dirname,
-        '/src/Components/Modals/CreateActivationKeyWizard.js'
+        '/src/Modules/CreateActivationKeyWizardWithContext.js'
       ),
     },
   },

--- a/src/Modules/CreateActivationKeyWizardWithContext.js
+++ b/src/Modules/CreateActivationKeyWizardWithContext.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { init, RegistryContext } from '../store';
+import logger from 'redux-logger';
+import Authentication from '../Components/Authentication';
+import CreateActivationKeyWizard from '../Components/Modals/CreateActivationKeyWizard';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 3,
+      retryDelay: 10 * 1000,
+      staleTime: Infinity,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+    },
+  },
+});
+
+const CreateActivationKeyWizardWithContext = (props) => {
+  const registry = IS_DEV ? init(logger) : init();
+  return (
+    <QueryClientProvider client={queryClient}>
+      <RegistryContext.Provider
+        value={{
+          getRegistry: () => registry,
+        }}
+      >
+        <Provider store={registry.getStore()}>
+          <Authentication>
+            <CreateActivationKeyWizard {...props} />
+          </Authentication>
+        </Provider>
+      </RegistryContext.Provider>
+    </QueryClientProvider>
+  );
+};
+
+export default CreateActivationKeyWizardWithContext;


### PR DESCRIPTION
We previously exported the CreateActivationKeys modal as a federated module, but it doesn't work as anticipated because it isn't wrapped in context.

This PR is exporting the component wrapped in context.