### PR TITLE
TUSC-334 - Updated the position of the button on AK table

### DIFF
--- a/src/Components/ActivationKeys/ActivationKeys.js
+++ b/src/Components/ActivationKeys/ActivationKeys.js
@@ -1,12 +1,7 @@
 import React, { useState } from 'react';
-import { ActionGroup } from '@patternfly/react-core/dist/dynamic/components/Form';
 import { Content } from '@patternfly/react-core/dist/dynamic/components/Content';
-
 import { ContentVariants } from '@patternfly/react-core/dist/dynamic/components/Content';
 import { PageSection } from '@patternfly/react-core/dist/dynamic/components/Page';
-
-import { Flex } from '@patternfly/react-core/dist/dynamic/layouts/Flex';
-import { FlexItem } from '@patternfly/react-core/dist/dynamic/layouts/Flex';
 import { Split } from '@patternfly/react-core/dist/dynamic/layouts/Split';
 import { SplitItem } from '@patternfly/react-core/dist/dynamic/layouts/Split';
 import {
@@ -76,18 +71,21 @@ const ActivationKeys = () => {
       <PageHeader>
         <Split hasGutter className="page-title">
           <SplitItem isFilled>
-            <Flex>
-              <FlexItem spacer={{ default: 'spacerSm' }}>
+            <Split>
+              <SplitItem spacer={{ default: 'spacerSm' }}>
                 <PageHeaderTitle title="Activation Keys" />
-              </FlexItem>
-              <FlexItem>
+              </SplitItem>
+              <SplitItem>
                 <ActivationKeysDocsPopover
                   popoverContent={popoverContent}
                   title="Activation Keys"
                   position="right"
                 />
-              </FlexItem>
-            </Flex>
+              </SplitItem>
+            </Split>
+          </SplitItem>
+          <SplitItem className="pf-v5-u-align-self-flex-start">
+            <CreateActivationKeyButton onClick={handleModalToggle} />
           </SplitItem>
         </Split>
         <Content>
@@ -101,9 +99,6 @@ const ActivationKeys = () => {
           {isLoading && <Loading />}
           {!isLoading && !error && data.length > 0 && (
             <>
-              <ActionGroup>
-                <CreateActivationKeyButton onClick={handleModalToggle} />
-              </ActionGroup>
               <ActivationKeysTable
                 onDelete={handleDeleteActivationKeyModalToggle}
               />

--- a/src/Components/ActivationKeys/ActivationKeys.js
+++ b/src/Components/ActivationKeys/ActivationKeys.js
@@ -84,9 +84,11 @@ const ActivationKeys = () => {
               </SplitItem>
             </Split>
           </SplitItem>
-          <SplitItem className="pf-v5-u-align-self-flex-start">
-            <CreateActivationKeyButton onClick={handleModalToggle} />
-          </SplitItem>
+          {!isLoading && !error && data.length > 0 && (
+            <SplitItem className="pf-v5-u-align-self-flex-start">
+              <CreateActivationKeyButton onClick={handleModalToggle} />
+            </SplitItem>
+          )}
         </Split>
         <Content>
           <Content component={ContentVariants.p}>

--- a/src/Components/ActivationKeys/__tests__/__snapshots__/ActivationKeys.test.js.snap
+++ b/src/Components/ActivationKeys/__tests__/__snapshots__/ActivationKeys.test.js.snap
@@ -16,10 +16,11 @@ exports[`ActivationKeys renders correctly 1`] = `
         class="pf-v6-l-split__item pf-m-fill"
       >
         <div
-          class="pf-v6-l-flex"
+          class="pf-v6-l-split"
         >
           <div
-            class="pf-m-spacer-sm"
+            class="pf-v6-l-split__item"
+            spacer="[object Object]"
           >
             <div
               class="pf-v6-l-flex pf-m-justify-content-space-between"
@@ -40,7 +41,7 @@ exports[`ActivationKeys renders correctly 1`] = `
             </div>
           </div>
           <div
-            class=""
+            class="pf-v6-l-split__item"
           >
             <div
               style="display: contents;"
@@ -75,6 +76,23 @@ exports[`ActivationKeys renders correctly 1`] = `
           </div>
         </div>
       </div>
+      <div
+        class="pf-v6-l-split__item pf-v5-u-align-self-flex-start"
+      >
+        <button
+          class="pf-v6-c-button pf-m-primary"
+          data-ouia-component-id="OUIA-Generated-Button-primary-1"
+          data-ouia-component-type="PF6/Button"
+          data-ouia-safe="true"
+          type="button"
+        >
+          <span
+            class="pf-v6-c-button__text"
+          >
+            Create activation key
+          </span>
+        </button>
+      </div>
     </div>
     <div
       class="pf-v6-c-content"
@@ -101,31 +119,6 @@ exports[`ActivationKeys renders correctly 1`] = `
     <section
       class="pf-v6-c-page__main-section"
     >
-      <div
-        class="pf-v6-c-form__group pf-m-action"
-      >
-        <div
-          class="pf-v6-c-form__group-control"
-        >
-          <div
-            class="pf-v6-c-form__actions"
-          >
-            <button
-              class="pf-v6-c-button pf-m-primary"
-              data-ouia-component-id="OUIA-Generated-Button-primary-1"
-              data-ouia-component-type="PF6/Button"
-              data-ouia-safe="true"
-              type="button"
-            >
-              <span
-                class="pf-v6-c-button__text"
-              >
-                Create activation key
-              </span>
-            </button>
-          </div>
-        </div>
-      </div>
       <div>
         Activation Keys Table
       </div>


### PR DESCRIPTION
## Summary by Sourcery

Reposition the 'Create Activation Key' button from below the table into the page header and adjust the header layout.

Enhancements:
- Replace Flex layout with Split for the page title and docs popover
- Move CreateActivationKeyButton into a header SplitItem and remove its previous ActionGroup wrapper

Tests:
- Update ActivationKeys component snapshot to account for the new layout