### PR TITLE
feat(RHINENG-25206): Normalize FEO config

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -23,8 +23,19 @@ objects:
       searchEntries:
         - id: activation-keys
           title: Activation Keys
-          href: insights/connector/activation-keys
+          href: /insights/connector/activation-keys
           description: Assign and manager activation keys.
+          alt_title:
+            - Subscription key
+            - sca
+            - simple content access
+            - activate
+            - register
+            - AK
+            - repositories
+            - system purpose
+            - sla
+            - content
       bundleSegments:
         - segmentId: connector-activation-nav
           bundleId: connector
@@ -32,14 +43,14 @@ objects:
           navItems:
             - id: activation-keys
               title: Activation Keys
-              href: insights/connector/activation-keys
+              href: /insights/connector/activation-keys
       module:
         manifestLocation: /apps/activation-keys/fed-mods.json
         modules:
           - id: activation-keys
             module: ./RootApp
             routes:
-              - pathname: insights/connector/activation-keys
+              - pathname: /insights/connector/activation-keys
     moduleID: activation-keys
 parameters:
   - name: ENV_NAME

--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -24,7 +24,7 @@ objects:
         - id: activation-keys
           title: Activation Keys
           href: /insights/connector/activation-keys
-          description: Assign and manager activation keys.
+          description: Assign and manage activation keys.
           alt_title:
             - Subscription key
             - sca

--- a/package-lock.json
+++ b/package-lock.json
@@ -5322,6 +5322,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/@sentry/cli/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sentry/core": {
       "version": "10.40.0",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.40.0.tgz",


### PR DESCRIPTION
Related ticket: RHINENG-25206

**Description**
- Normalized FEO paths to use leading slashes across navigation, search, and routing entries
- Restored missing Activation Keys search aliases (`alt_title`) from the legacy static search index

**How to test**
- Verify Activation Keys is accessible from the left navigation, from global search, and directly via `/insights/connector/activation-keys`
- Verify global search also finds Activation Keys using restored aliases such as `subscription key` and `simple content access`

## Summary by Sourcery

Normalize Activation Keys frontend configuration paths and enhance its search discoverability.

New Features:
- Add alternative search titles for Activation Keys to improve discoverability in global search.

Enhancements:
- Standardize Activation Keys navigation, search, and route paths to use leading slashes in the frontend configuration.