### PR TITLE
Preload, shrink retry timer, and don't reset query

### DIFF
--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -8,7 +8,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: 3,
-      retryDelay: 10 * 1000,
+      retryDelay: 1 * 1000,
       staleTime: Infinity,
       refetchOnWindowFocus: false,
       refetchOnMount: false,

--- a/src/Components/Authentication/Authentication.js
+++ b/src/Components/Authentication/Authentication.js
@@ -12,6 +12,9 @@ const Authentication = ({ children }) => {
     isLoading: canReadActivationKeysIsLoading,
   } = useHasRelation(Relation.KEYS_VIEW);
 
+  // Preload edit for later
+  useHasRelation(Relation.KEYS_EDIT);
+
   const { isLoading, isFetching, isError } = useUser();
 
   if (isError) {

--- a/src/Components/Modals/ActivationKeyWizard.js
+++ b/src/Components/Modals/ActivationKeyWizard.js
@@ -210,7 +210,9 @@ const ActivationKeyWizard = ({
   const onClose = () => {
     queryClient.invalidateQueries({ queryKey: ['activation_keys'] });
     if (activationKey?.name) {
-      queryClient.invalidateQueries({ queryKey: [`activation_key_${activationKey.name}`] });
+      queryClient.invalidateQueries({
+        queryKey: [`activation_key_${activationKey.name}`],
+      });
     }
     handleModalToggle();
   };

--- a/src/Components/Modals/ActivationKeyWizard.js
+++ b/src/Components/Modals/ActivationKeyWizard.js
@@ -211,7 +211,6 @@ const ActivationKeyWizard = ({
     queryClient.invalidateQueries(['activation_keys']);
     if (activationKey?.name) {
       queryClient.invalidateQueries([`activation_key_${activationKey.name}`]);
-      queryClient.resetQueries([`activation_key_${activationKey.name}`]);
     }
     handleModalToggle();
   };

--- a/src/Components/Modals/ActivationKeyWizard.js
+++ b/src/Components/Modals/ActivationKeyWizard.js
@@ -208,9 +208,9 @@ const ActivationKeyWizard = ({
   }, [releaseVersions, extendedReleaseProduct, extendedReleaseVersion]);
 
   const onClose = () => {
-    queryClient.invalidateQueries(['activation_keys']);
+    queryClient.invalidateQueries({ queryKey: ['activation_keys'] });
     if (activationKey?.name) {
-      queryClient.invalidateQueries([`activation_key_${activationKey.name}`]);
+      queryClient.invalidateQueries({ queryKey: [`activation_key_${activationKey.name}`] });
     }
     handleModalToggle();
   };

--- a/src/Components/Modals/AddAdditionalRepositoriesModal.js
+++ b/src/Components/Modals/AddAdditionalRepositoriesModal.js
@@ -35,10 +35,8 @@ const AddAdditionalRepositoriesModal = (props) => {
       { selectedRepositories, keyName },
       {
         onSuccess: () => {
-          queryClient.invalidateQueries([`activation_key_${keyName}`]);
-          queryClient.invalidateQueries([
-            `activation_key_${keyName}_available_repositories`,
-          ]);
+          queryClient.invalidateQueries({ queryKey: [`activation_key_${keyName}`] });
+          queryClient.invalidateQueries({ queryKey: [`activation_key_${keyName}_available_repositories`] });
           addSuccessNotification(
             `Repositories have been added for '${keyName}'`,
           );

--- a/src/Components/Modals/AddAdditionalRepositoriesModal.js
+++ b/src/Components/Modals/AddAdditionalRepositoriesModal.js
@@ -35,8 +35,12 @@ const AddAdditionalRepositoriesModal = (props) => {
       { selectedRepositories, keyName },
       {
         onSuccess: () => {
-          queryClient.invalidateQueries({ queryKey: [`activation_key_${keyName}`] });
-          queryClient.invalidateQueries({ queryKey: [`activation_key_${keyName}_available_repositories`] });
+          queryClient.invalidateQueries({
+            queryKey: [`activation_key_${keyName}`],
+          });
+          queryClient.invalidateQueries({
+            queryKey: [`activation_key_${keyName}_available_repositories`],
+          });
           addSuccessNotification(
             `Repositories have been added for '${keyName}'`,
           );

--- a/src/Components/Modals/AddAdditionalRepositoriesModal.js
+++ b/src/Components/Modals/AddAdditionalRepositoriesModal.js
@@ -35,13 +35,14 @@ const AddAdditionalRepositoriesModal = (props) => {
       { selectedRepositories, keyName },
       {
         onSuccess: () => {
-          queryClient.resetQueries([`activation_key_${keyName}`]);
-          queryClient.resetQueries([
+          queryClient.invalidateQueries([`activation_key_${keyName}`]);
+          queryClient.invalidateQueries([
             `activation_key_${keyName}_available_repositories`,
           ]);
           addSuccessNotification(
             `Repositories have been added for '${keyName}'`,
           );
+          handleModalToggle();
         },
         onError: () => {
           addErrorNotification('Something went wrong', {

--- a/src/Components/Modals/DeleteAdditionalRepositoriesModal.js
+++ b/src/Components/Modals/DeleteAdditionalRepositoriesModal.js
@@ -38,10 +38,7 @@ const DeleteAdditionalRepositoriesModal = (props) => {
     mutate(
       { name, payload },
       {
-        onSuccess: (data, queryName) => {
-          const updatedData = data?.filter(
-            (entry) => entry.repositoryName !== repositoryNameToDelete,
-          );
+        onSuccess: (_data, queryName) => {
           addSuccessNotification(
             `Additional repository ${repositoryNameToDelete} deleted`,
           );

--- a/src/Components/Modals/DeleteAdditionalRepositoriesModal.js
+++ b/src/Components/Modals/DeleteAdditionalRepositoriesModal.js
@@ -45,7 +45,7 @@ const DeleteAdditionalRepositoriesModal = (props) => {
           addSuccessNotification(
             `Additional repository ${repositoryNameToDelete} deleted`,
           );
-          queryClient.invalidateQueries(queryName, updatedData);
+          queryClient.invalidateQueries({ queryKey: [queryName] });
           handleModalToggle();
         },
         onError: () => {


### PR DESCRIPTION
## Summary by Sourcery

Improve activation key data handling, user flow, and request retry behavior across the application.

Enhancements:
- Switch activation key-related queries from full resets to targeted invalidation to avoid unnecessary query state resets.
- Close the AddAdditionalRepositories modal automatically after successfully adding repositories.
- Preload the activation key edit permission relation during authentication to reduce latency for later edit operations.
- Reduce the global query retry delay from 10 seconds to 1 second to make failed requests surface and recover more quickly.
- Remove redundant query reset for individual activation keys after invalidation in the activation key wizard.