### PR TITLE
TUSC-582: Use api call directly

### DIFF
--- a/src/hooks/__tests__/useHasRelation.test.js
+++ b/src/hooks/__tests__/useHasRelation.test.js
@@ -1,5 +1,5 @@
 import {
-  fetchDefaultWorkspace,
+  // fetchDefaultWorkspace, TODO: Add back once the sdk is fixed
   useAccessCheckContext,
 } from '@project-kessel/react-kessel-access-check';
 import { checkSelf } from '@project-kessel/react-kessel-access-check/core/api-client';
@@ -9,6 +9,17 @@ import { createQueryWrapper } from '../../utils/testHelpers';
 
 jest.mock('@project-kessel/react-kessel-access-check');
 jest.mock('@project-kessel/react-kessel-access-check/core/api-client');
+
+// ------------------------------------------------------------
+// TODO: remove once sdk is used for default workspace fetching
+// ------------------------------------------------------------
+
+import { fetchDefaultWorkspace } from '../../utils/fetchDefaultWorkspace';
+jest.mock('../../utils/fetchDefaultWorkspace');
+
+// ------------------------------------------------------------
+// TODO: End remove block
+// ------------------------------------------------------------
 
 describe('useHasRelation hook', () => {
   beforeEach(() => {

--- a/src/hooks/useHasRelation.js
+++ b/src/hooks/useHasRelation.js
@@ -1,9 +1,10 @@
 import {
-  fetchDefaultWorkspace,
+  // fetchDefaultWorkspace, TODO: Add back once the sdk is fixed
   useAccessCheckContext,
 } from '@project-kessel/react-kessel-access-check';
 import { checkSelf } from '@project-kessel/react-kessel-access-check/core/api-client';
 import { useQuery } from '@tanstack/react-query';
+import { fetchDefaultWorkspace } from '../utils/fetchDefaultWorkspace'; // TODO remove once sdk is fixed
 
 // 5 minutes * 60 seconds * 1000 milliseconds
 const QUERY_STALE_TIME = 5 * 60 * 1000;

--- a/src/utils/fetchDefaultWorkspace.js
+++ b/src/utils/fetchDefaultWorkspace.js
@@ -1,0 +1,22 @@
+// ------------------------------------------------------------
+// TODO: remove file once sdk is used for default workspace fetching
+// ------------------------------------------------------------
+
+export const fetchDefaultWorkspace = async (rbacBaseEndpoint) => {
+  const url = `${rbacBaseEndpoint.replace(/\/+$/, '')}/api/rbac/v2/workspaces/?type=default&with_ancestry=true`;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      'Content-type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('failed to fetch default workspace');
+  }
+
+  const data = await response.json();
+
+  return data.data[0];
+};


### PR DESCRIPTION
This fixes an issue with the kessel sdk's implementation of default workspace fetching. Once it has been fixed, these changes (marked clearly with TODOs) can be removed.

## Summary by Sourcery

Temporarily bypass the kessel SDK for default workspace fetching by introducing a local fetch helper and wiring it into the useHasRelation hook and its tests.

New Features:
- Add a local fetchDefaultWorkspace utility to retrieve the default workspace directly from the RBAC API.

Bug Fixes:
- Work around an issue in the kessel SDK's default workspace fetching by using a direct API call instead.

Enhancements:
- Isolate default workspace fetching logic into a dedicated utility to simplify future reversion back to the SDK.

Tests:
- Update useHasRelation hook tests to mock the new fetchDefaultWorkspace utility instead of the SDK export.