### PR TITLE
Add claudemd and update linting rules

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "none",
+  "printWidth": 100
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md
+
+## Project Overview
+
+Activation Keys UI is a Red Hat Insights micro-frontend for managing subscription activation keys, served on `console.redhat.com`. Built with React/JavaScript and loaded into the Insights Chrome shell via Webpack Module Federation (`fec` CLI).
+
+## Common Commands
+
+- `npm run start` — dev server with proxy (requires Red Hat VPN + proxy setup)
+- `npm run build` — production build
+- `npm run test` — run Jest tests
+- `npm run lint` — ESLint + Stylelint
+- `npm run verify` — build + lint + test (full CI check)
+
+## Architecture & Conventions
+
+- Functional components only, arrow functions
+- PascalCase directories with `index.js` barrel exports for each component
+- Types colocated with hooks/components (no central types directory)
+- PatternFly v6 for UI components
+- Plain JavaScript (`.js` files) — no TypeScript
+- Native `fetch` + TanStack React Query v5 for data fetching; JWT auth via `useChrome()` from platform services
+- React Router v6
+- No Redux — React Query for server state, React Context for notifications, `useState` for UI state
+- Feature flags via Unleash (`useFeatureFlag` hook wraps `@unleash/proxy-client-react`)
+- Authorization via Kessel (`@project-kessel/react-kessel-access-check`) for relation-based access control
+- Prefer code reuse over duplication — extract shared logic into hooks or utilities
+- Prefer small, focused React components over large complex ones
+- Stay in scope — do not refactor or "improve" unrelated code when working on a feature. Instead, note potential improvements for the developer as a follow-up for a future ticket
+
+## Testing
+
+- Jest 30 (with `jest-jasmine2` runner) + React Testing Library + jest-fetch-mock
+- Tests colocated in `__tests__/` subdirectories
+- BDD-style lazy vars (`def`/`get`) from `bdd-lazy-var` used in some test files
+- `createQueryWrapper()` from `src/utils/testHelpers.js` for wrapping hook tests
+- Global test setup in `config/setupTests.js` mocks `useChrome`, `useNavigate`, and `useInsightsNavigate`
+- New features must include unit tests
+- Do NOT use snapshot tests — test observable behavior and functionality (what the user sees and does), not implementation details (internal state, component structure, CSS classes). Legacy snapshot tests exist but should not be expanded
+- Pre-existing test failures are a code smell — if existing tests break after your changes, investigate the unintended consequences rather than just updating the test to pass. The failing test may be revealing buggy behavior introduced by your changes
+
+## Key Caveats
+
+- App runs inside Red Hat Insights Chrome shell — `useChrome()` provides auth, navigation, and environment
+- Local dev requires Red Hat VPN and proxy setup
+- `fec.config.js` configures Webpack/Module Federation — app exposes `./RootApp` and `./CreateActivationKeyWizard`

--- a/config/cypress.webpack.config.js
+++ b/config/cypress.webpack.config.js
@@ -1,9 +1,9 @@
 const { resolve } = require('path');
 const config = require('@redhat-cloud-services/frontend-components-config');
 const { config: webpackConfig, plugins } = config({
-  rootFolder: resolve(__dirname, '../'),
+  rootFolder: resolve(__dirname, '../')
 });
 module.exports = {
   ...webpackConfig,
-  plugins,
+  plugins
 };

--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -15,33 +15,33 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
             account_number: '0',
             type: 'User',
             user: {
-              is_org_admin: true,
-            },
+              is_org_admin: true
+            }
           },
           entitlements: {
             hybrid_cloud: { is_entitled: true },
             insights: { is_entitled: true },
             openshift: { is_entitled: true },
-            smart_management: { is_entitled: false },
-          },
-        }),
+            smart_management: { is_entitled: false }
+          }
+        })
     },
     appAction: jest.fn(),
     appObjectId: jest.fn(),
     on: jest.fn(),
-    getUserPermissions: () => Promise.resolve(['inventory:*:*']),
-  }),
+    getUserPermissions: () => Promise.resolve(['inventory:*:*'])
+  })
 }));
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useNavigate: () => () => {},
+  useNavigate: () => () => {}
 }));
 
 jest.mock(
   '@redhat-cloud-services/frontend-components-utilities/useInsightsNavigate/useInsightsNavigate',
   () => ({
     __esModule: true,
-    default: () => () => {},
-  }),
+    default: () => () => {}
+  })
 );

--- a/config/test.webpack.config.js
+++ b/config/test.webpack.config.js
@@ -1,10 +1,10 @@
 const { resolve } = require('path');
 const config = require('@redhat-cloud-services/frontend-components-config');
 const { config: webpackConfig, plugins } = config({
-  rootFolder: resolve(__dirname, '../'),
+  rootFolder: resolve(__dirname, '../')
 });
 
 module.exports = {
   ...webpackConfig,
-  plugins,
+  plugins
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "jest-fetch-mock": "^3.0.3",
         "jest-jasmine2": "^30.0.0",
         "npm-run-all2": "9.0.2",
+        "prettier": "^3.9.6",
         "prop-types": "15.8.1",
         "stylelint": "^16.10.0",
         "stylelint-config-recommended-scss": "16.0.2",
@@ -16321,9 +16322,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "jest-fetch-mock": "^3.0.3",
     "jest-jasmine2": "^30.0.0",
     "npm-run-all2": "9.0.2",
+    "prettier": "^3.9.6",
     "prop-types": "15.8.1",
     "stylelint": "^16.10.0",
     "stylelint-config-recommended-scss": "16.0.2",

--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -11,18 +11,15 @@ const queryClient = new QueryClient({
       retryDelay: 1 * 1000,
       staleTime: Infinity,
       refetchOnWindowFocus: false,
-      refetchOnMount: false,
-    },
-  },
+      refetchOnMount: false
+    }
+  }
 });
 
 const AppEntry = () => {
   return (
     <QueryClientProvider client={queryClient}>
-      <AccessCheck.Provider
-        baseUrl={window.location.origin}
-        apiPath="/api/kessel/v1beta2"
-      >
+      <AccessCheck.Provider baseUrl={window.location.origin} apiPath="/api/kessel/v1beta2">
         <Authentication>
           <App />
         </Authentication>

--- a/src/Components/ActivationKey/ActivationKey.js
+++ b/src/Components/ActivationKey/ActivationKey.js
@@ -10,10 +10,7 @@ import { Level } from '@patternfly/react-core/dist/dynamic/layouts/Level';
 import { LevelItem } from '@patternfly/react-core/dist/dynamic/layouts/Level';
 import { DescriptionListGroup } from '@patternfly/react-core/dist/dynamic/components/DescriptionList';
 import { DescriptionListTerm } from '@patternfly/react-core/dist/dynamic/components/DescriptionList';
-import {
-  PageHeader,
-  PageHeaderTitle,
-} from '@redhat-cloud-services/frontend-components/PageHeader';
+import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components/PageHeader';
 import AdditionalRepositoriesCard from './AdditionalRepositoriesCard';
 import NoAccessPopover from '../NoAccessPopover';
 import useActivationKey from '../../hooks/useActivationKey';
@@ -27,22 +24,15 @@ import { Relation, useHasRelation } from '../../hooks/useHasRelation';
 const ActivationKey = () => {
   const { id } = useParams();
 
-  const {
-    has: canWriteActivationKeys,
-    isLoading: canWriteActivationKeysIsLoading,
-  } = useHasRelation(Relation.KEYS_EDIT);
+  const { has: canWriteActivationKeys, isLoading: canWriteActivationKeysIsLoading } =
+    useHasRelation(Relation.KEYS_EDIT);
 
   const breadcrumbs = [
     { title: 'Activation Keys', to: '..' },
-    { title: id, isActive: true },
+    { title: id, isActive: true }
   ];
-  const {
-    isLoading: isKeyLoading,
-    error: keyError,
-    data: activationKey,
-  } = useActivationKey(id);
-  const [isEditActivationKeyWizardOpen, setIsEditActivationKeyWizardOpen] =
-    useState(false);
+  const { isLoading: isKeyLoading, error: keyError, data: activationKey } = useActivationKey(id);
+  const [isEditActivationKeyWizardOpen, setIsEditActivationKeyWizardOpen] = useState(false);
   const handleEditActivationKeyWizardToggle = () => {
     setIsEditActivationKeyWizardOpen(!isEditActivationKeyWizardOpen);
   };
@@ -63,8 +53,7 @@ const ActivationKey = () => {
             </DescriptionListGroup>
           </LevelItem>
           <LevelItem className="pf-v6-u-mb-sm">
-            {!(isKeyLoading || canWriteActivationKeysIsLoading) &&
-            canWriteActivationKeys ? (
+            {!(isKeyLoading || canWriteActivationKeysIsLoading) && canWriteActivationKeys ? (
               <EditAndDeleteDropdown
                 onClick={handleEditActivationKeyWizardToggle}
                 activationKey={activationKey}
@@ -85,7 +74,7 @@ const ActivationKey = () => {
                 <Gallery
                   hasGutter
                   minWidths={{
-                    default: '40%',
+                    default: '40%'
                   }}
                 >
                   <GalleryItem>

--- a/src/Components/ActivationKey/ActivationKeyDescription.js
+++ b/src/Components/ActivationKey/ActivationKeyDescription.js
@@ -6,14 +6,8 @@ import { HelperText } from '@patternfly/react-core/dist/dynamic/components/Helpe
 import { HelperTextItem } from '@patternfly/react-core/dist/dynamic/components/HelperText';
 import { Form } from '@patternfly/react-core/dist/dynamic/components/Form';
 import { TextArea } from '@patternfly/react-core/dist/dynamic/components/TextArea';
-const ActivationKeyDescription = ({
-  mode,
-  description,
-  setDescription,
-  descriptionIsValid,
-}) => {
-  const [enableValidationFeedback, setEnableValidationFeedback] =
-    useState(false);
+const ActivationKeyDescription = ({ mode, description, setDescription, descriptionIsValid }) => {
+  const [enableValidationFeedback, setEnableValidationFeedback] = useState(false);
 
   const handleChange = (event) => {
     setDescription(event.target.value);
@@ -23,8 +17,7 @@ const ActivationKeyDescription = ({
     setEnableValidationFeedback(true);
   };
   const helperText = 'Max characters is 255.';
-  const validated =
-    descriptionIsValid || !enableValidationFeedback ? 'default' : 'error';
+  const validated = descriptionIsValid || !enableValidationFeedback ? 'default' : 'error';
   const helperTextInvalid = `Description requirements have not been met. ${helperText}`;
   return (
     <Form
@@ -37,11 +30,7 @@ const ActivationKeyDescription = ({
         fieldId="activation-key-description"
       >
         <TextArea
-          id={
-            mode === 'edit'
-              ? 'edit-activation-key-description'
-              : 'activation-key-description'
-          }
+          id={mode === 'edit' ? 'edit-activation-key-description' : 'activation-key-description'}
           value={description}
           onChange={handleChange}
           validated={validated}
@@ -62,6 +51,6 @@ ActivationKeyDescription.propTypes = {
   mode: PropTypes.oneOf(['create', 'edit']).isRequired,
   description: PropTypes.string,
   setDescription: PropTypes.func.isRequired,
-  descriptionIsValid: PropTypes.bool.isRequired,
+  descriptionIsValid: PropTypes.bool.isRequired
 };
 export default ActivationKeyDescription;

--- a/src/Components/ActivationKey/AddAdditionalRepositoriesButton.js
+++ b/src/Components/ActivationKey/AddAdditionalRepositoriesButton.js
@@ -5,11 +5,7 @@ import { WriteOnlyButton } from '../WriteOnlyButton';
 const AddAdditionalRepositoriesButton = ({ onClick }) => {
   return (
     <React.Fragment>
-      <WriteOnlyButton
-        onClick={onClick}
-        variant="secondary"
-        style={{ margin: 15, marginLeft: 0 }}
-      >
+      <WriteOnlyButton onClick={onClick} variant="secondary" style={{ margin: 15, marginLeft: 0 }}>
         Add repositories
       </WriteOnlyButton>
     </React.Fragment>
@@ -17,7 +13,7 @@ const AddAdditionalRepositoriesButton = ({ onClick }) => {
 };
 
 AddAdditionalRepositoriesButton.propTypes = {
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func.isRequired
 };
 
 export default AddAdditionalRepositoriesButton;

--- a/src/Components/ActivationKey/AdditionalRepositoriesCard.js
+++ b/src/Components/ActivationKey/AdditionalRepositoriesCard.js
@@ -16,15 +16,11 @@ import AddAdditionalRepositoriesModal from '../Modals/AddAdditionalRepositoriesM
 const AdditionalRepositoriesCard = (props) => {
   const { activationKey } = props;
 
-  const [
-    isEditAdditionalRepositoriesModalOpen,
-    setisEditAdditionalRepositoriesModalOpen,
-  ] = useState(false);
+  const [isEditAdditionalRepositoriesModalOpen, setisEditAdditionalRepositoriesModalOpen] =
+    useState(false);
 
   const handleEditAdditionalRepositoriesToggle = () => {
-    setisEditAdditionalRepositoriesModalOpen(
-      !isEditAdditionalRepositoriesModalOpen,
-    );
+    setisEditAdditionalRepositoriesModalOpen(!isEditAdditionalRepositoriesModalOpen);
   };
 
   return (
@@ -37,13 +33,11 @@ const AdditionalRepositoriesCard = (props) => {
       <CardBody>
         <Content>
           <Content component={ContentVariants.p}>
-            The core repositories for your operating system version, for example
-            BaseOS and AppStream, are always enabled and do not need to be
-            explicitly added to the activation key.
+            The core repositories for your operating system version, for example BaseOS and
+            AppStream, are always enabled and do not need to be explicitly added to the activation
+            key.
           </Content>
-          <AddAdditionalRepositoriesButton
-            onClick={handleEditAdditionalRepositoriesToggle}
-          />
+          <AddAdditionalRepositoriesButton onClick={handleEditAdditionalRepositoriesToggle} />
           <AddAdditionalRepositoriesModal
             isOpen={isEditAdditionalRepositoriesModalOpen}
             handleModalToggle={handleEditAdditionalRepositoriesToggle}
@@ -62,7 +56,7 @@ const AdditionalRepositoriesCard = (props) => {
 AdditionalRepositoriesCard.propTypes = {
   activationKey: propTypes.object,
   isLoading: propTypes.bool,
-  error: propTypes.bool,
+  error: propTypes.bool
 };
 
 export default AdditionalRepositoriesCard;

--- a/src/Components/ActivationKey/EditAndDeleteDropdown.js
+++ b/src/Components/ActivationKey/EditAndDeleteDropdown.js
@@ -20,10 +20,8 @@ export const EditAndDeleteDropdown = ({ activationKey, onClick }) => {
     setIsOpen(false);
   };
 
-  const [isDeleteActivationKeyModalOpen, setIsDeleteActivationKeyModalOpen] =
-    useState(false);
-  const [isEditActivationKeyWizardOpen, setIsEditActivationKeyWizardOpen] =
-    useState(false);
+  const [isDeleteActivationKeyModalOpen, setIsDeleteActivationKeyModalOpen] = useState(false);
+  const [isEditActivationKeyWizardOpen, setIsEditActivationKeyWizardOpen] = useState(false);
 
   const handleDeleteActivationKeysModalToggle = (keyDeleted) => {
     setIsDeleteActivationKeyModalOpen(!isDeleteActivationKeyModalOpen);
@@ -46,11 +44,7 @@ export const EditAndDeleteDropdown = ({ activationKey, onClick }) => {
         onSelect={onSelect}
         onOpenChange={(isOpen) => setIsOpen(isOpen)}
         toggle={(toggleRef) => (
-          <MenuToggle
-            ref={toggleRef}
-            onClick={onToggleClick}
-            isExpanded={isOpen}
-          >
+          <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
             Actions
           </MenuToggle>
         )}
@@ -100,7 +94,7 @@ export const EditAndDeleteDropdown = ({ activationKey, onClick }) => {
 EditAndDeleteDropdown.propTypes = {
   onClick: propTypes.func.isRequired,
   activationKey: propTypes.object,
-  activationKeyName: propTypes.string,
+  activationKeyName: propTypes.string
 };
 
 export default EditAndDeleteDropdown;

--- a/src/Components/ActivationKey/SystemPurposeCard.js
+++ b/src/Components/ActivationKey/SystemPurposeCard.js
@@ -17,10 +17,9 @@ const SystemPurposeCard = ({ activationKey }) => {
   const docsPopoverContent = (
     <Content>
       <Content component="p">
-        System purpose values are used by the subscriptions service to help
-        filter and identify hosts. Setting values for these attributes is
-        optional, but doing so ensures that subscriptions reporting accurately
-        reflects the system.
+        System purpose values are used by the subscriptions service to help filter and identify
+        hosts. Setting values for these attributes is optional, but doing so ensures that
+        subscriptions reporting accurately reflects the system.
       </Content>
     </Content>
   );
@@ -30,10 +29,7 @@ const SystemPurposeCard = ({ activationKey }) => {
         <CardTitle>
           <Title headingLevel="h2">
             System Purpose{' '}
-            <ActivationKeysDocsPopover
-              popoverContent={docsPopoverContent}
-              position="top"
-            />{' '}
+            <ActivationKeysDocsPopover popoverContent={docsPopoverContent} position="top" />{' '}
           </Title>
         </CardTitle>
       </CardHeader>
@@ -42,9 +38,7 @@ const SystemPurposeCard = ({ activationKey }) => {
           <Content component={ContentVariants.dl}>
             <Content component={ContentVariants.dt}>Role</Content>
             <Content component={ContentVariants.dd}>
-              {activationKey && activationKey.role
-                ? activationKey.role
-                : notDefinedText}
+              {activationKey && activationKey.role ? activationKey.role : notDefinedText}
             </Content>
             <Content component={ContentVariants.dt}>SLA</Content>
             <Content component={ContentVariants.dd}>
@@ -54,9 +48,7 @@ const SystemPurposeCard = ({ activationKey }) => {
             </Content>
             <Content component={ContentVariants.dt}>Usage</Content>
             <Content component={ContentVariants.dd}>
-              {activationKey && activationKey.usage
-                ? activationKey.usage
-                : notDefinedText}
+              {activationKey && activationKey.usage ? activationKey.usage : notDefinedText}
             </Content>
           </Content>
         </Content>
@@ -66,7 +58,7 @@ const SystemPurposeCard = ({ activationKey }) => {
 };
 
 SystemPurposeCard.propTypes = {
-  activationKey: propTypes.object,
+  activationKey: propTypes.object
 };
 
 export default SystemPurposeCard;

--- a/src/Components/ActivationKey/WorkloadCard.js
+++ b/src/Components/ActivationKey/WorkloadCard.js
@@ -17,10 +17,10 @@ const WorkloadCard = ({ activationKey }) => {
   const docsPopoverContent = (
     <Content>
       <Content component="p">
-        A release version enables you to configure your system to use a specific
-        minor release of Red Hat Enterprise Linux. Setting a release version is
-        useful if you are using an extended release of software, such as
-        Extended Update Support. Most users will not set a release version.
+        A release version enables you to configure your system to use a specific minor release of
+        Red Hat Enterprise Linux. Setting a release version is useful if you are using an extended
+        release of software, such as Extended Update Support. Most users will not set a release
+        version.
       </Content>
     </Content>
   );
@@ -30,10 +30,7 @@ const WorkloadCard = ({ activationKey }) => {
         <CardTitle>
           <Title headingLevel="h2">
             Workload{' '}
-            <ActivationKeysDocsPopover
-              popoverContent={docsPopoverContent}
-              position="top"
-            />
+            <ActivationKeysDocsPopover popoverContent={docsPopoverContent} position="top" />
           </Title>
         </CardTitle>
       </CardHeader>
@@ -54,7 +51,7 @@ const WorkloadCard = ({ activationKey }) => {
 };
 
 WorkloadCard.propTypes = {
-  activationKey: propTypes.object,
+  activationKey: propTypes.object
 };
 
 export default WorkloadCard;

--- a/src/Components/ActivationKey/__tests__/ActivationKey.test.js
+++ b/src/Components/ActivationKey/__tests__/ActivationKey.test.js
@@ -17,8 +17,8 @@ jest.mock('../../../hooks/useUser');
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: () => ({
-    pathname: '/',
-  }),
+    pathname: '/'
+  })
 }));
 jest.mock('../../../hooks/useHasRelation');
 
@@ -37,14 +37,14 @@ const PageContainer = () => (
 const mockAuthenticateUser = (isLoading, isError) => {
   const user = {
     accountNumber: '123',
-    orgId: '123',
+    orgId: '123'
   };
   useUser.mockReturnValue({
     isLoading: isLoading,
     isFetching: false,
     isSuccess: true,
     isError: isError,
-    data: user,
+    data: user
   });
   if (isError === false) {
     queryClient.setQueryData(['user'], user);
@@ -54,7 +54,7 @@ const mockAuthenticateUser = (isLoading, isError) => {
 const mockRelation = (map) => {
   useHasRelation.mockImplementation((r) => ({
     has: map?.[r] || false,
-    isLoading: false,
+    isLoading: false
   }));
 };
 
@@ -63,20 +63,18 @@ jest.mock('../../../Components/AdditionalRepositoriesTable', () => () => (
   <div>Additional Repositories Table</div>
 ));
 // eslint-disable-next-line react/display-name
-jest.mock('../../../Components/shared/breadcrumbs', () => () => (
-  <div>Breadcrumbs</div>
-));
+jest.mock('../../../Components/shared/breadcrumbs', () => () => <div>Breadcrumbs</div>);
 
 jest.mock(
   '@redhat-cloud-services/frontend-components/NotAuthorized',
   // eslint-disable-next-line react/display-name
-  () => () => <div>Not Authorized</div>,
+  () => () => <div>Not Authorized</div>
 );
 
 jest.mock(
   '@redhat-cloud-services/frontend-components/Unavailable',
   // eslint-disable-next-line react/display-name
-  () => () => <div>Unavailable</div>,
+  () => () => <div>Unavailable</div>
 );
 
 describe('ActivationKey', () => {
@@ -90,24 +88,20 @@ describe('ActivationKey', () => {
       serviceLevel: 'C',
       usage: 'D',
       additionalRepositories: [],
-      releaseVersion: 1,
+      releaseVersion: 1
     };
   });
 
   beforeEach(() => {
     jest.resetAllMocks();
-    mockAuthenticateUser(
-      get('isLoading'),
-      get('isError'),
-      get('rbacPermissions'),
-    );
+    mockAuthenticateUser(get('isLoading'), get('isError'), get('rbacPermissions'));
     mockRelation(get('relations'));
     useActivationKey.mockReturnValue({
       isLoading: false,
       isFetching: false,
       isError: false,
       isSuccess: true,
-      data: get('keyData'),
+      data: get('keyData')
     });
   });
 
@@ -117,18 +111,16 @@ describe('ActivationKey', () => {
       isFetching: false,
       isError: false,
       isSuccess: true,
-      data: [], // Mock the data that the hook returns
+      data: [] // Mock the data that the hook returns
     });
 
     render(
       <QueryClientProvider client={queryClient}>
         <PageContainer />
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
 
-    await waitFor(() =>
-      expect(screen.getByText('System Purpose')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('System Purpose')).toBeInTheDocument());
     expect(screen.getByText('Workload')).toBeInTheDocument();
     expect(screen.getByText('Additional repositories')).toBeInTheDocument();
   });
@@ -150,9 +142,7 @@ describe('ActivationKey', () => {
 
     it('redirects to not authorized page', async () => {
       render(<PageContainer />);
-      await waitFor(() =>
-        expect(screen.getByText('Not Authorized')).toBeInTheDocument(),
-      );
+      await waitFor(() => expect(screen.getByText('Not Authorized')).toBeInTheDocument());
     });
   });
 });

--- a/src/Components/ActivationKeys/ActivationKeys.js
+++ b/src/Components/ActivationKeys/ActivationKeys.js
@@ -4,10 +4,7 @@ import { ContentVariants } from '@patternfly/react-core/dist/dynamic/components/
 import { PageSection } from '@patternfly/react-core/dist/dynamic/components/Page';
 import { Split } from '@patternfly/react-core/dist/dynamic/layouts/Split';
 import { SplitItem } from '@patternfly/react-core/dist/dynamic/layouts/Split';
-import {
-  PageHeader,
-  PageHeaderTitle,
-} from '@redhat-cloud-services/frontend-components/PageHeader';
+import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components/PageHeader';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import ActivationKeysTable from '../ActivationKeysTable';
 import NoActivationKeysFound from '../EmptyState';
@@ -28,8 +25,7 @@ const ActivationKeys = () => {
   const [currentKeyName, setCurrentKeyName] = useState('');
   const { data: user } = useUser();
 
-  const [isDeleteActivationKeyModalOpen, setIsDeleteActivationKeyModalOpen] =
-    useState(false);
+  const [isDeleteActivationKeyModalOpen, setIsDeleteActivationKeyModalOpen] = useState(false);
   const handleModalToggle = () => {
     setisOpen(!isOpen);
   };
@@ -40,9 +36,9 @@ const ActivationKeys = () => {
   const popoverContent = (
     <Content className="pf-v6-u-font-size-sm">
       <Content component="p">
-        Activation keys assist you in registering systems. Metadata such as
-        role, system purpose, and usage can be automatically attached to systems
-        via an activation key, and monitored with &nbsp;
+        Activation keys assist you in registering systems. Metadata such as role, system purpose,
+        and usage can be automatically attached to systems via an activation key, and monitored with
+        &nbsp;
         <a
           target="_blank"
           rel="noopener noreferrer"
@@ -55,8 +51,7 @@ const ActivationKeys = () => {
         </a>
       </Content>
       <Content component="p">
-        To register with an activation key, you will need your organization ID:{' '}
-        <b>{user.orgId}</b>
+        To register with an activation key, you will need your organization ID: <b>{user.orgId}</b>
       </Content>
     </Content>
   );
@@ -96,9 +91,7 @@ const ActivationKeys = () => {
           )}
         </Split>
         <Content>
-          <Content component={ContentVariants.p}>
-            Organization ID: {user.orgId}
-          </Content>
+          <Content component={ContentVariants.p}>Organization ID: {user.orgId}</Content>
         </Content>
       </PageHeader>
       <Main>
@@ -106,9 +99,7 @@ const ActivationKeys = () => {
           {isLoading && <Loading />}
           {!isLoading && !error && data.length > 0 && (
             <>
-              <ActivationKeysTable
-                onDelete={handleDeleteActivationKeyModalToggle}
-              />
+              <ActivationKeysTable onDelete={handleDeleteActivationKeyModalToggle} />
             </>
           )}
           {!isLoading && !error && !data.length && (
@@ -116,11 +107,7 @@ const ActivationKeys = () => {
           )}
         </PageSection>
       </Main>
-      <ActivationKeyWizard
-        key={isOpen}
-        isOpen={isOpen}
-        handleModalToggle={handleModalToggle}
-      />
+      <ActivationKeyWizard key={isOpen} isOpen={isOpen} handleModalToggle={handleModalToggle} />
       <DeleteActivationKeyConfirmationModal
         handleModalToggle={handleDeleteActivationKeyModalToggle}
         isOpen={isDeleteActivationKeyModalOpen}

--- a/src/Components/ActivationKeys/CreateActivationKeyButton.js
+++ b/src/Components/ActivationKeys/CreateActivationKeyButton.js
@@ -11,7 +11,7 @@ const CreateActivationKeyButton = ({ onClick }) => {
 };
 
 CreateActivationKeyButton.propTypes = {
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func.isRequired
 };
 
 export default CreateActivationKeyButton;

--- a/src/Components/ActivationKeys/DeleteActivationKeyButton.js
+++ b/src/Components/ActivationKeys/DeleteActivationKeyButton.js
@@ -16,7 +16,7 @@ const DeleteActivationKeyButton = ({ onClick }) => {
 };
 
 DeleteActivationKeyButton.propTypes = {
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func.isRequired
 };
 
 export default DeleteActivationKeyButton;

--- a/src/Components/ActivationKeys/EditButton.js
+++ b/src/Components/ActivationKeys/EditButton.js
@@ -3,8 +3,7 @@ import propTypes from 'prop-types';
 import ActivationKeyWizard from '../Modals/ActivationKeyWizard';
 
 const EditButton = ({ activationKey, releaseVersions }) => {
-  const [isEditActivationKeyWizardOpen, setIsEditActivationKeyWizardOpen] =
-    useState(false);
+  const [isEditActivationKeyWizardOpen, setIsEditActivationKeyWizardOpen] = useState(false);
 
   const handleEditActivationKeyWizardToggle = () => {
     setIsEditActivationKeyWizardOpen(!isEditActivationKeyWizardOpen);
@@ -25,7 +24,7 @@ const EditButton = ({ activationKey, releaseVersions }) => {
 
 EditButton.propTypes = {
   activationKey: propTypes.object,
-  releaseVersions: propTypes.array,
+  releaseVersions: propTypes.array
 };
 
 export default EditButton;

--- a/src/Components/ActivationKeys/__tests__/ActivationKeys.test.js
+++ b/src/Components/ActivationKeys/__tests__/ActivationKeys.test.js
@@ -15,8 +15,8 @@ jest.mock('../../../hooks/useUser');
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: () => ({
-    pathname: '/',
-  }),
+    pathname: '/'
+  })
 }));
 jest.mock('../../../hooks/useHasRelation');
 
@@ -35,21 +35,21 @@ const PageContainer = () => (
 const mockRelation = (map) => {
   useHasRelation.mockImplementation((r) => ({
     has: map?.[r] || false,
-    isLoading: false,
+    isLoading: false
   }));
 };
 
 const mockAuthenticateUser = (isLoading, isError) => {
   const user = {
     accountNumber: '123',
-    orgId: '123',
+    orgId: '123'
   };
   useUser.mockReturnValue({
     isLoading: isLoading,
     isFetching: false,
     isSuccess: true,
     isError: isError,
-    data: user,
+    data: user
   });
 
   if (isError === false) {
@@ -58,19 +58,17 @@ const mockAuthenticateUser = (isLoading, isError) => {
 };
 
 // eslint-disable-next-line react/display-name
-jest.mock('../../../Components/ActivationKeysTable', () => () => (
-  <div>Activation Keys Table</div>
-));
+jest.mock('../../../Components/ActivationKeysTable', () => () => <div>Activation Keys Table</div>);
 jest.mock(
   '@redhat-cloud-services/frontend-components/NotAuthorized',
   // eslint-disable-next-line react/display-name
-  () => () => <div>Not Authorized</div>,
+  () => () => <div>Not Authorized</div>
 );
 
 jest.mock(
   '@redhat-cloud-services/frontend-components/Unavailable',
   // eslint-disable-next-line react/display-name
-  () => () => <div>Unavailable</div>,
+  () => () => <div>Unavailable</div>
 );
 
 describe('ActivationKeys', () => {
@@ -84,8 +82,8 @@ describe('ActivationKeys', () => {
       name: 'A',
       role: 'B',
       serviceLevel: 'C',
-      usage: 'D',
-    },
+      usage: 'D'
+    }
   ]);
 
   beforeEach(() => {
@@ -97,7 +95,7 @@ describe('ActivationKeys', () => {
       isFetching: false,
       isError: false,
       isSuccess: true,
-      data: get('keysData'),
+      data: get('keysData')
     });
   });
 
@@ -136,9 +134,7 @@ describe('ActivationKeys', () => {
     it('create activation key button is disabled', async () => {
       render(<PageContainer />);
       await waitFor(() =>
-        expect(
-          screen.getByText('Create activation key').parentElement,
-        ).toBeDisabled(),
+        expect(screen.getByText('Create activation key').parentElement).toBeDisabled()
       );
     });
   });

--- a/src/Components/ActivationKeysDocsPopover/ActivationKeysDocsPopover.js
+++ b/src/Components/ActivationKeysDocsPopover/ActivationKeysDocsPopover.js
@@ -11,7 +11,7 @@ const ActivationKeysDocsPopover = (props) => {
     right: PopoverPosition.rightStart,
     left: PopoverPosition.leftStart,
     top: PopoverPosition.top,
-    bottom: PopoverPosition.bottom,
+    bottom: PopoverPosition.bottom
   };
   return (
     <Popover
@@ -35,5 +35,5 @@ export default ActivationKeysDocsPopover;
 ActivationKeysDocsPopover.propTypes = {
   popoverContent: propTypes.object,
   title: propTypes.string,
-  position: propTypes.string,
+  position: propTypes.string
 };

--- a/src/Components/ActivationKeysTable/ActivationKeysTable.js
+++ b/src/Components/ActivationKeysTable/ActivationKeysTable.js
@@ -15,7 +15,7 @@ const ActivationKeysTable = (props) => {
     role: 'Role',
     serviceLevel: 'SLA',
     usage: 'Usage',
-    updatedAt: 'Updated Date',
+    updatedAt: 'Updated Date'
   };
   const { isLoading, error, data } = useActivationKeys();
   const [activeSortIndex, setActiveSortIndex] = React.useState(null);
@@ -32,12 +32,12 @@ const ActivationKeysTable = (props) => {
   const getSortParams = () => ({
     sortBy: {
       index: activeSortIndex,
-      direction: sortDirection,
+      direction: sortDirection
     },
     onSort: (_event, index, direction) => {
       setActiveSortIndex(index);
       setSortDirection(direction);
-    },
+    }
   });
 
   const Results = () => {
@@ -63,19 +63,13 @@ const ActivationKeysTable = (props) => {
                   <Link to={`${datum.name}`}> {datum.name}</Link>
                 </Td>
                 <Td dataLabel={columnNames.role}>{datum.role}</Td>
-                <Td dataLabel={columnNames.serviceLevel}>
-                  {datum.serviceLevel}
-                </Td>
+                <Td dataLabel={columnNames.serviceLevel}>{datum.serviceLevel}</Td>
                 <Td dataLabel={columnNames.usage}>{datum.usage}</Td>
                 <Td dataLabel={columnNames.updatedAt}>
-                  {datum.updatedAt
-                    ? printDate(datum.updatedAt)
-                    : 'Not Available'}
+                  {datum.updatedAt ? printDate(datum.updatedAt) : 'Not Available'}
                 </Td>
                 <Td>
-                  <DeleteActivationKeyButton
-                    onClick={() => onDelete(datum.name)}
-                  />
+                  <DeleteActivationKeyButton onClick={() => onDelete(datum.name)} />
                 </Td>
               </Tr>
             );
@@ -95,7 +89,7 @@ const ActivationKeysTable = (props) => {
 };
 
 ActivationKeysTable.propTypes = {
-  onDelete: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired
 };
 
 export default ActivationKeysTable;

--- a/src/Components/ActivationKeysTable/__tests__/ActivationKeysTable.test.js
+++ b/src/Components/ActivationKeysTable/__tests__/ActivationKeysTable.test.js
@@ -13,7 +13,7 @@ jest.mock('uuid', () => {
 });
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useLocation: () => ({ pathname: '/connector/test-key' }),
+  useLocation: () => ({ pathname: '/connector/test-key' })
 }));
 jest.mock('../../../hooks/useHasRelation');
 
@@ -22,7 +22,7 @@ const queryClient = new QueryClient();
 const mockRelation = (map) => {
   useHasRelation.mockImplementation((r) => ({
     has: map?.[r] || false,
-    isLoading: false,
+    isLoading: false
   }));
 };
 
@@ -37,7 +37,7 @@ const Table = () => (
 jest.mock(
   '@redhat-cloud-services/frontend-components/Unavailable',
   // eslint-disable-next-line react/display-name
-  () => () => <div>Unavailable</div>,
+  () => () => <div>Unavailable</div>
 );
 
 describe('ActivationKeysTable', () => {
@@ -51,15 +51,15 @@ describe('ActivationKeysTable', () => {
       name: 'A',
       role: 'B',
       serviceLevel: 'C',
-      usage: 'D',
-    },
+      usage: 'D'
+    }
   ]);
 
   beforeEach(() => {
     useActivationKeys.mockReturnValue({
       isLoading: get('loading'),
       error: get('error'),
-      data: get('data'),
+      data: get('data')
     });
     mockRelation(get('relations'));
   });

--- a/src/Components/AddAdditionalRepositoriesTable/AddAdditionalRepositoriesTable.js
+++ b/src/Components/AddAdditionalRepositoriesTable/AddAdditionalRepositoriesTable.js
@@ -8,7 +8,7 @@ import { EmptyStateActions } from '@patternfly/react-core/dist/dynamic/component
 
 import { EmptyStateFooter } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
 import useAvailableRepositories, {
-  usePrefetchAvailableRepositoriesNextPage,
+  usePrefetchAvailableRepositoriesNextPage
 } from '../../hooks/useAvailableRepositories';
 import SearchIcon from '@patternfly/react-icons/dist/dynamic/icons/search-icon';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
@@ -20,12 +20,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useDebouncedState } from '../../hooks/useDebouncedState';
 
 const AddAdditionalRepositoriesTable = (props) => {
-  const {
-    keyName,
-    selectedRepositories,
-    setSelectedRepositories,
-    isSubmitting,
-  } = props;
+  const { keyName, selectedRepositories, setSelectedRepositories, isSubmitting } = props;
 
   const sort_by_index = ['repo_name', 'repo_label'];
 
@@ -34,8 +29,7 @@ const AddAdditionalRepositoriesTable = (props) => {
   const [rpmTypeFilter, setRpmTypeFilter] = useState([]);
   const [architectureFilter, setArchitectureFilter] = useState([]);
   const queryClient = useQueryClient();
-  const [onlyShowSelectedRepositories, setOnlyShowSelectedRepositories] =
-    useState(false);
+  const [onlyShowSelectedRepositories, setOnlyShowSelectedRepositories] = useState(false);
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
   const [activeSortIndex, setActiveSortIndex] = useState(0);
@@ -45,7 +39,7 @@ const AddAdditionalRepositoriesTable = (props) => {
     repo_name: 'Name',
     repo_label: 'Label',
     rpm_type: 'RPM Type',
-    architecture: 'Architecture',
+    architecture: 'Architecture'
   };
 
   const filters = {
@@ -55,38 +49,34 @@ const AddAdditionalRepositoriesTable = (props) => {
       value: rpmTypeFilter,
       set: setRpmTypeFilter,
       opts: ['binary', 'debug', 'source'],
-      placeholder: 'Type',
+      placeholder: 'Type'
     },
     architecture: {
       value: architectureFilter,
       set: setArchitectureFilter,
       opts: ['aarch64', 'ia64', 'ppc', 's390x', 'x86'],
-      placeholder: 'Type',
-    },
+      placeholder: 'Type'
+    }
   };
 
   const attrMap = {
     repo_name: 'repositoryName',
     repo_label: 'repositoryLabel',
     rpm_type: 'rpmType',
-    architecture: 'architecture',
+    architecture: 'architecture'
   };
 
   const matchFilters = (repository) => {
     for (const [k, filter] of Object.entries(filters)) {
       if (!Array.isArray(filter.value)) {
-        if (
-          !repository[attrMap[k]]
-            .toLowerCase()
-            .includes(filter.value.toLowerCase())
-        ) {
+        if (!repository[attrMap[k]].toLowerCase().includes(filter.value.toLowerCase())) {
           return false;
         }
       } else {
         if (
           filter.value.length > 0 &&
           filter.value.filter((option) =>
-            repository[attrMap[k]].toLowerCase().includes(option.toLowerCase()),
+            repository[attrMap[k]].toLowerCase().includes(option.toLowerCase())
           ).length == 0
         ) {
           return false;
@@ -104,10 +94,10 @@ const AddAdditionalRepositoriesTable = (props) => {
       repo_name: repoNameFilter,
       repo_label: repoLabelFilter,
       rpm_type: rpmTypeFilter,
-      architecture: architectureFilter,
+      architecture: architectureFilter
     },
     activeSortBy,
-    activeSortDirection,
+    activeSortDirection
   );
 
   const prefetchNextPage = usePrefetchAvailableRepositoriesNextPage();
@@ -126,10 +116,10 @@ const AddAdditionalRepositoriesTable = (props) => {
         repo_name: repoNameFilter,
         repo_label: repoLabelFilter,
         rpm_type: rpmTypeFilter,
-        architecture: architectureFilter,
+        architecture: architectureFilter
       },
       activeSortBy,
-      activeSortDirection,
+      activeSortDirection
     );
   }, [page, perPage, JSON.stringify(filters)]);
 
@@ -137,19 +127,17 @@ const AddAdditionalRepositoriesTable = (props) => {
     sortBy: {
       index: activeSortIndex,
       direction: activeSortDirection,
-      defaultDirection: 'asc',
+      defaultDirection: 'asc'
     },
     onSort: (_event, index, direction) => {
       setActiveSortIndex(index);
       setActiveSortDirection(direction);
       setActiveSortBy(sort_by_index[index]);
     },
-    columnIndex,
+    columnIndex
   });
 
-  const filteredRepos = selectedRepositories.filter((repo) =>
-    matchFilters(repo),
-  );
+  const filteredRepos = selectedRepositories.filter((repo) => matchFilters(repo));
 
   const displayedSelectedRepos = filteredRepos
     .filter((_, i) => {
@@ -170,9 +158,7 @@ const AddAdditionalRepositoriesTable = (props) => {
   const pagination = (
     <Pagination
       itemCount={
-        onlyShowSelectedRepositories
-          ? filteredRepos.length
-          : repositoriesData?.pagination.total
+        onlyShowSelectedRepositories ? filteredRepos.length : repositoriesData?.pagination.total
       }
       perPage={perPage}
       page={page}
@@ -187,11 +173,7 @@ const AddAdditionalRepositoriesTable = (props) => {
   );
 
   const emptyState = (
-    <EmptyState
-      headingLevel="h2"
-      icon={SearchIcon}
-      titleText="No results found"
-    >
+    <EmptyState headingLevel="h2" icon={SearchIcon} titleText="No results found">
       <EmptyStateBody>
         No results match the filter criteria. Clear all filters and try again.
       </EmptyStateBody>
@@ -223,9 +205,7 @@ const AddAdditionalRepositoriesTable = (props) => {
         filters={filters}
         dropdownSelectisDisabled={isSubmitting}
         selectedOnlyToggleIsDisabled={
-          (!onlyShowSelectedRepositories &&
-            selectedRepositories.length === 0) ||
-          isSubmitting
+          (!onlyShowSelectedRepositories && selectedRepositories.length === 0) || isSubmitting
         }
         searchIsDisabled={isSubmitting}
         pagination={pagination}
@@ -242,56 +222,46 @@ const AddAdditionalRepositoriesTable = (props) => {
         </Thead>
         <Tbody>
           {(!isLoading || onlyShowSelectedRepositories) &&
-            (onlyShowSelectedRepositories
-              ? displayedSelectedRepos
-              : repositoriesData.body
-            ).map((repository, rowIndex) => (
-              <Tr key={repository.repositoryLabel}>
-                <Td
-                  select={{
-                    rowIndex,
-                    isSelected:
-                      selectedRepositories.find(
-                        (selected) =>
-                          repository.repositoryLabel ==
-                          selected.repositoryLabel,
-                      ) != undefined,
-                    onSelect: (_, isSelecting) => {
-                      if (isSubmitting) {
-                        return;
-                      }
-                      if (isSelecting) {
-                        if (
-                          selectedRepositories.find(
-                            (selected) =>
-                              selected.repositoryLabel ==
-                              repository.repositoryLabel,
-                          ) == undefined
-                        ) {
-                          setSelectedRepositories([
-                            ...selectedRepositories,
-                            repository,
-                          ]);
+            (onlyShowSelectedRepositories ? displayedSelectedRepos : repositoriesData.body).map(
+              (repository, rowIndex) => (
+                <Tr key={repository.repositoryLabel}>
+                  <Td
+                    select={{
+                      rowIndex,
+                      isSelected:
+                        selectedRepositories.find(
+                          (selected) => repository.repositoryLabel == selected.repositoryLabel
+                        ) != undefined,
+                      onSelect: (_, isSelecting) => {
+                        if (isSubmitting) {
+                          return;
                         }
-                      } else {
-                        setSelectedRepositories(
-                          selectedRepositories.filter(
-                            (selectedRepository) =>
-                              selectedRepository.repositoryLabel !==
-                              repository.repositoryLabel,
-                          ),
-                        );
+                        if (isSelecting) {
+                          if (
+                            selectedRepositories.find(
+                              (selected) => selected.repositoryLabel == repository.repositoryLabel
+                            ) == undefined
+                          ) {
+                            setSelectedRepositories([...selectedRepositories, repository]);
+                          }
+                        } else {
+                          setSelectedRepositories(
+                            selectedRepositories.filter(
+                              (selectedRepository) =>
+                                selectedRepository.repositoryLabel !== repository.repositoryLabel
+                            )
+                          );
+                        }
                       }
-                    },
-                  }}
-                />
-                <Td>{repository.repositoryName}</Td>
-                <Td>{repository.repositoryLabel}</Td>
-              </Tr>
-            ))}
+                    }}
+                  />
+                  <Td>{repository.repositoryName}</Td>
+                  <Td>{repository.repositoryLabel}</Td>
+                </Tr>
+              )
+            )}
           {((repositoriesData && repositoriesData.body.length === 0) ||
-            (onlyShowSelectedRepositories &&
-              displayedSelectedRepos.length === 0)) && (
+            (onlyShowSelectedRepositories && displayedSelectedRepos.length === 0)) && (
             <Tr>
               <Td colSpan={8}>
                 <Bullseye>{emptyState}</Bullseye>
@@ -318,7 +288,7 @@ AddAdditionalRepositoriesTable.propTypes = {
   keyName: propTypes.string.isRequired,
   selectedRepositories: propTypes.array.isRequired,
   setSelectedRepositories: propTypes.func.isRequired,
-  isSubmitting: propTypes.bool,
+  isSubmitting: propTypes.bool
 };
 
 export default AddAdditionalRepositoriesTable;

--- a/src/Components/AddAdditionalRepositoriesTable/AddAdditionalRepositoriesToolbar.js
+++ b/src/Components/AddAdditionalRepositoriesTable/AddAdditionalRepositoriesToolbar.js
@@ -6,10 +6,7 @@ import { ToolbarContent } from '@patternfly/react-core/dist/dynamic/components/T
 import { ToolbarGroup } from '@patternfly/react-core/dist/dynamic/components/Toolbar';
 import { ToolbarItem } from '@patternfly/react-core/dist/dynamic/components/Toolbar';
 import { ToggleGroup } from '@patternfly/react-core/dist/dynamic/components/ToggleGroup';
-import {
-  Select,
-  SelectList,
-} from '@patternfly/react-core/dist/dynamic/components/Select';
+import { Select, SelectList } from '@patternfly/react-core/dist/dynamic/components/Select';
 import { SelectOption } from '@patternfly/react-core/dist/dynamic/components/Select';
 import FilterIcon from '@patternfly/react-icons/dist/dynamic/icons/filter-icon';
 import propTypes from 'prop-types';
@@ -25,13 +22,11 @@ const AddAdditionalRepositoriesToolbar = ({
   dropdownSelectisDisabled,
   pagination,
   onlyShowSelectedRepositories,
-  setOnlyShowSelectedRepositories,
+  setOnlyShowSelectedRepositories
 }) => {
-  const [isSelectFilterByExpanded, setIsSelectFilterByExpanded] =
-    useState(false);
+  const [isSelectFilterByExpanded, setIsSelectFilterByExpanded] = useState(false);
 
-  const [isMultiSelectOptionsExanded, setIsMultiSelectOptionsExpanded] =
-    useState(false);
+  const [isMultiSelectOptionsExanded, setIsMultiSelectOptionsExpanded] = useState(false);
 
   const [activeFilter, setActiveFilter] = useState(Object.keys(filters)[0]);
 
@@ -46,9 +41,7 @@ const AddAdditionalRepositoriesToolbar = ({
                 <MenuToggle
                   ref={toggleRef}
                   icon={<FilterIcon />}
-                  onClick={() =>
-                    setIsSelectFilterByExpanded(!isSelectFilterByExpanded)
-                  }
+                  onClick={() => setIsSelectFilterByExpanded(!isSelectFilterByExpanded)}
                   isExpanded={isSelectFilterByExpanded}
                 >
                   {friendlyNameMap[activeFilter]}
@@ -64,11 +57,7 @@ const AddAdditionalRepositoriesToolbar = ({
               <SelectList>
                 {Object.entries(filters).map(([k, v]) => {
                   return (
-                    <SelectOption
-                      value={[k, v]}
-                      key={k}
-                      isFocused={activeFilter == k}
-                    >
+                    <SelectOption value={[k, v]} key={k} isFocused={activeFilter == k}>
                       {friendlyNameMap[k]}
                     </SelectOption>
                   );
@@ -94,21 +83,14 @@ const AddAdditionalRepositoriesToolbar = ({
                   <MenuToggle
                     ref={toggleRef}
                     icon={<FilterIcon />}
-                    onClick={() =>
-                      setIsMultiSelectOptionsExpanded(
-                        !isMultiSelectOptionsExanded,
-                      )
-                    }
+                    onClick={() => setIsMultiSelectOptionsExpanded(!isMultiSelectOptionsExanded)}
                     isExpanded={isMultiSelectOptionsExanded}
                   >
                     {filters[activeFilter].placeholder}
                   </MenuToggle>
                 )}
                 onSelect={(_, value) => {
-                  filters[activeFilter].set([
-                    ...filters[activeFilter].value,
-                    value,
-                  ]);
+                  filters[activeFilter].set([...filters[activeFilter].value, value]);
                   setIsMultiSelectOptionsExpanded(false);
                 }}
                 onOpenChange={(isOpen) => {
@@ -162,9 +144,7 @@ const AddAdditionalRepositoriesToolbar = ({
       <ToolbarContent>
         <ToolbarGroup>
           {Object.entries(filters)
-            .filter(([, v]) =>
-              Array.isArray(v.value) ? v.value.length > 0 : v.value !== '',
-            )
+            .filter(([, v]) => (Array.isArray(v.value) ? v.value.length > 0 : v.value !== ''))
             .map(([k, v]) => (
               <ToolbarItem key={k}>
                 <LabelGroup categoryName={friendlyNameMap[k]}>
@@ -205,7 +185,7 @@ AddAdditionalRepositoriesToolbar.propTypes = {
   pagination: propTypes.object.isRequired,
   onlyShowSelectedRepositories: propTypes.bool.isRequired,
   setOnlyShowSelectedRepositories: propTypes.func.isRequired,
-  dropdownSelectisDisabled: propTypes.bool.isRequired,
+  dropdownSelectisDisabled: propTypes.bool.isRequired
 };
 
 export default AddAdditionalRepositoriesToolbar;

--- a/src/Components/AdditionalRepositoriesTable/AdditionalRepositoriesTable.js
+++ b/src/Components/AdditionalRepositoriesTable/AdditionalRepositoriesTable.js
@@ -15,13 +15,11 @@ const AdditionalRepositoriesTable = (props) => {
   const [activeSortDirection, setActiveSortDirection] = useState(null);
   const [repositoryNameToDelete, setRepositoryNameToDelete] = useState('');
   const [repositoryLabelToDelete, setRepositoryLabelToDelete] = useState('');
-  const [
-    isDeleteAdditionalRepositoriesModalOpen,
-    setisDeleteAdditionalRepositoriesModalOpen,
-  ] = useState(false);
+  const [isDeleteAdditionalRepositoriesModalOpen, setisDeleteAdditionalRepositoriesModalOpen] =
+    useState(false);
   const columnNames = {
     repositoryLabel: 'Label',
-    repositoryName: 'Name',
+    repositoryName: 'Name'
   };
 
   const getSortableRowValues = (repo) => {
@@ -33,13 +31,13 @@ const AdditionalRepositoriesTable = (props) => {
     sortBy: {
       index: activeSortIndex,
       direction: activeSortDirection,
-      defaultDirection: 'asc',
+      defaultDirection: 'asc'
     },
     onSort: (_event, index, direction) => {
       setActiveSortIndex(index);
       setActiveSortDirection(direction);
     },
-    columnIndex,
+    columnIndex
   });
 
   const sortRepos = (repositories, sortIndex) => {
@@ -100,13 +98,8 @@ const AdditionalRepositoriesTable = (props) => {
   const sortedRepositories = sortRepos(repositories, activeSortIndex);
   const paginatedRepos = getPage(sortedRepositories);
 
-  const handleDeleteAdditionalRepositoriesToggle = (
-    repositoryName,
-    repositoryLabel,
-  ) => {
-    setisDeleteAdditionalRepositoriesModalOpen(
-      !isDeleteAdditionalRepositoriesModalOpen,
-    );
+  const handleDeleteAdditionalRepositoriesToggle = (repositoryName, repositoryLabel) => {
+    setisDeleteAdditionalRepositoriesModalOpen(!isDeleteAdditionalRepositoriesModalOpen);
     setRepositoryNameToDelete(repositoryName);
     setRepositoryLabelToDelete(repositoryLabel);
   };
@@ -128,18 +121,14 @@ const AdditionalRepositoriesTable = (props) => {
           {paginatedRepos?.map((repository, rowIndex) => {
             return (
               <Tr key={rowIndex} ouiaSafe={true}>
-                <Td dataLabel={columnNames.repositoryName}>
-                  {repository.repositoryName}
-                </Td>
-                <Td dataLabel={columnNames.repositoryLabel}>
-                  {repository.repositoryLabel}
-                </Td>
+                <Td dataLabel={columnNames.repositoryName}>{repository.repositoryName}</Td>
+                <Td dataLabel={columnNames.repositoryLabel}>{repository.repositoryLabel}</Td>
                 <Td>
                   <RemoveAdditionalRepositoriesButton
                     onClick={() =>
                       handleDeleteAdditionalRepositoriesToggle(
                         repository.repositoryName,
-                        repository.repositoryLabel,
+                        repository.repositoryLabel
                       )
                     }
                   />
@@ -171,7 +160,7 @@ const AdditionalRepositoriesTable = (props) => {
 
 AdditionalRepositoriesTable.propTypes = {
   repositories: propTypes.array.isRequired,
-  name: propTypes.string.isRequired,
+  name: propTypes.string.isRequired
 };
 
 export default AdditionalRepositoriesTable;

--- a/src/Components/AdditionalRepositoriesTable/NoAdditionalRepositories.js
+++ b/src/Components/AdditionalRepositoriesTable/NoAdditionalRepositories.js
@@ -7,14 +7,8 @@ import AddCircleOIcon from '@patternfly/react-icons/dist/dynamic/icons/add-circl
 const NoAdditionalRepositories = () => {
   return (
     <>
-      <EmptyState
-        headingLevel="h5"
-        icon={AddCircleOIcon}
-        titleText="No additional repositories"
-      >
-        <EmptyStateBody>
-          You currently have no additional repositories to display.
-        </EmptyStateBody>
+      <EmptyState headingLevel="h5" icon={AddCircleOIcon} titleText="No additional repositories">
+        <EmptyStateBody>You currently have no additional repositories to display.</EmptyStateBody>
       </EmptyState>
     </>
   );

--- a/src/Components/AdditionalRepositoriesTable/RemoveAdditionalRepositoriesButton.js
+++ b/src/Components/AdditionalRepositoriesTable/RemoveAdditionalRepositoriesButton.js
@@ -17,7 +17,7 @@ const RemoveAdditionalRepositoriesButton = ({ onClick }) => {
 };
 
 RemoveAdditionalRepositoriesButton.propTypes = {
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func.isRequired
 };
 
 export default RemoveAdditionalRepositoriesButton;

--- a/src/Components/AdditionalRepositoriesTable/__tests__/AdditionalRepositoriesTable.test.js
+++ b/src/Components/AdditionalRepositoriesTable/__tests__/AdditionalRepositoriesTable.test.js
@@ -13,7 +13,7 @@ jest.mock('uuid', () => {
 jest.mock('../../../hooks/useUser');
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useRouteMatch: () => ({ url: '/' }),
+  useRouteMatch: () => ({ url: '/' })
 }));
 jest.mock('../../../hooks/useHasRelation');
 
@@ -22,7 +22,7 @@ const queryClient = new QueryClient();
 const mockRelation = (map) => {
   useHasRelation.mockImplementation((r) => ({
     has: map?.[r] || false,
-    isLoading: false,
+    isLoading: false
   }));
 };
 
@@ -37,24 +37,24 @@ describe('AdditionalRepositoriesTable', () => {
       name: 'A',
       role: 'B',
       serviceLevel: 'C',
-      usage: 'D',
-    },
+      usage: 'D'
+    }
   ]);
   beforeEach(() => {
     useAvailableRepositories.mockReturnValue({
       isLoading: get('loading'),
       error: get('error'),
-      data: get('data'),
+      data: get('data')
     });
     mockRelation(get('relations'));
   });
   const repositories = [
     {
-      repositoryLabel: 'label-a',
+      repositoryLabel: 'label-a'
     },
     {
-      repositoryLabel: 'label-b',
-    },
+      repositoryLabel: 'label-b'
+    }
   ];
 
   jest.mock('../../../hooks/useUser', () => ({
@@ -67,10 +67,10 @@ describe('AdditionalRepositoriesTable', () => {
       data: {
         rbacPermissions: {
           canReadActivationKeys: true,
-          canWriteActivationKeys: true,
-        },
-      },
-    }),
+          canWriteActivationKeys: true
+        }
+      }
+    })
   }));
 
   it('renders correctly', () => {
@@ -88,14 +88,14 @@ describe('AdditionalRepositoriesTable', () => {
   describe('when row column headings are clicked', () => {
     const repositories = [
       {
-        repositoryLabel: 'label-a',
+        repositoryLabel: 'label-a'
       },
       {
-        repositoryLabel: 'label-b',
+        repositoryLabel: 'label-b'
       },
       {
-        repositoryLabel: 'label-c',
-      },
+        repositoryLabel: 'label-c'
+      }
     ];
 
     it('can sort by name', () => {
@@ -155,7 +155,7 @@ describe('AdditionalRepositoriesTable', () => {
 
   describe('when using pagination', () => {
     const repositories = [...Array(12).keys()].map((id) => ({
-      repositoryLabel: `label-${id}`,
+      repositoryLabel: `label-${id}`
     }));
     it('can change page', () => {
       const Table = () => (

--- a/src/Components/Authentication/Authentication.js
+++ b/src/Components/Authentication/Authentication.js
@@ -7,10 +7,9 @@ import useUser from '../../hooks/useUser';
 import Unavailable from '@redhat-cloud-services/frontend-components/Unavailable';
 
 const Authentication = ({ children }) => {
-  const {
-    has: canReadActivationKeys,
-    isLoading: canReadActivationKeysIsLoading,
-  } = useHasRelation(Relation.KEYS_VIEW);
+  const { has: canReadActivationKeys, isLoading: canReadActivationKeysIsLoading } = useHasRelation(
+    Relation.KEYS_VIEW
+  );
 
   // Preload edit for later
   useHasRelation(Relation.KEYS_EDIT);
@@ -29,7 +28,7 @@ const Authentication = ({ children }) => {
 };
 
 Authentication.propTypes = {
-  children: propTypes.node,
+  children: propTypes.node
 };
 
 export default Authentication;

--- a/src/Components/Authentication/__tests__/Authentication.test.js
+++ b/src/Components/Authentication/__tests__/Authentication.test.js
@@ -9,8 +9,8 @@ import { Relation, useHasRelation } from '../../../hooks/useHasRelation';
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: () => ({
-    pathname: '/',
-  }),
+    pathname: '/'
+  })
 }));
 jest.mock('../../../hooks/useUser');
 jest.mock('../../../hooks/useHasRelation');
@@ -20,14 +20,14 @@ const queryClient = new QueryClient();
 const mockAuthenticateUser = (isLoading = true, isError = false) => {
   const user = {
     accountNumber: '123',
-    orgId: '123',
+    orgId: '123'
   };
   useUser.mockReturnValue({
     isLoading: isLoading,
     isFetching: false,
     isSuccess: true,
     isError: isError,
-    data: user,
+    data: user
   });
 
   if (isError === false) {
@@ -38,7 +38,7 @@ const mockAuthenticateUser = (isLoading = true, isError = false) => {
 const mockRelation = (map) => {
   useHasRelation.mockImplementation((r) => ({
     has: map?.[r] || false,
-    isLoading: false,
+    isLoading: false
   }));
 };
 
@@ -57,11 +57,7 @@ describe('Authentication', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
-    mockAuthenticateUser(
-      get('isLoading'),
-      get('isError'),
-      get('rbacPermissions'),
-    );
+    mockAuthenticateUser(get('isLoading'), get('isError'), get('rbacPermissions'));
     mockRelation(get('relations'));
   });
 

--- a/src/Components/EmptyState/NoActivationKeysFound.js
+++ b/src/Components/EmptyState/NoActivationKeysFound.js
@@ -11,15 +11,10 @@ const NoActivationKeysFound = (props) => {
   const { handleModalToggle } = props;
   return (
     <>
-      <EmptyState
-        headingLevel="h5"
-        icon={AddCircleOIcon}
-        titleText="No activation keys"
-      >
+      <EmptyState headingLevel="h5" icon={AddCircleOIcon} titleText="No activation keys">
         <EmptyStateBody>
-          You currently have no activation keys to display. Activation keys
-          allow you to register a system with system purpose, role and usage
-          attached.
+          You currently have no activation keys to display. Activation keys allow you to register a
+          system with system purpose, role and usage attached.
         </EmptyStateBody>
         <EmptyStateFooter>
           <CreateActivationKeyButton onClick={handleModalToggle} />
@@ -30,7 +25,7 @@ const NoActivationKeysFound = (props) => {
 };
 
 NoActivationKeysFound.propTypes = {
-  handleModalToggle: PropTypes.func.isRequired,
+  handleModalToggle: PropTypes.func.isRequired
 };
 
 export default NoActivationKeysFound;

--- a/src/Components/Forms/ActivationKeyForm.js
+++ b/src/Components/Forms/ActivationKeyForm.js
@@ -18,8 +18,7 @@ import PropTypes from 'prop-types';
 import useNotifications from '../../hooks/useNotifications';
 
 const ActivationKeyForm = (props) => {
-  const { handleModalToggle, submitForm, isSuccess, isError, activationKey } =
-    props;
+  const { handleModalToggle, submitForm, isSuccess, isError, activationKey } = props;
   const { addSuccessNotification, addErrorNotification } = useNotifications();
   const { isLoading, error, data } = useSystemPurposeAttributes();
   const [name, setName] = useState('');
@@ -38,7 +37,7 @@ const ActivationKeyForm = (props) => {
         name: name,
         role: role,
         serviceLevel: serviceLevel,
-        usage: usage,
+        usage: usage
       });
     } else {
       setValidated('error');
@@ -72,9 +71,7 @@ const ActivationKeyForm = (props) => {
         activationKey.usage === usage
       );
     } else {
-      return (
-        validated === 'error' || name.length === 0 || !name.match(nameRegex)
-      );
+      return validated === 'error' || name.length === 0 || !name.match(nameRegex);
     }
   };
 
@@ -83,7 +80,7 @@ const ActivationKeyForm = (props) => {
       ? `Activation key ${activationKey.name} updated successfully.`
       : 'Activation key created successfully.';
     addSuccessNotification(successMessage, {
-      timeout: false,
+      timeout: false
     });
     handleModalToggle();
   } else if (isError) {
@@ -91,7 +88,7 @@ const ActivationKeyForm = (props) => {
       ? `Error updating activation key ${activationKey.name}.`
       : 'Activation Key was not created, please try again.';
     addErrorNotification(errorMessage, {
-      timeout: 8000,
+      timeout: 8000
     });
     handleModalToggle();
   }
@@ -111,9 +108,7 @@ const ActivationKeyForm = (props) => {
           />
           <FormHelperText>
             <HelperText>
-              <HelperTextItem variant={validated}>
-                {validationText}
-              </HelperTextItem>
+              <HelperTextItem variant={validated}>{validationText}</HelperTextItem>
             </HelperText>
           </FormHelperText>
         </FormGroup>
@@ -138,12 +133,10 @@ const ActivationKeyForm = (props) => {
               bodyContent={
                 <Content>
                   <Content component={ContentVariants.p}>
-                    Role is used to categorize systems by the workload on the
-                    system
+                    Role is used to categorize systems by the workload on the system
                   </Content>
                   <Content component={ContentVariants.p}>
-                    Subscription Watch can help you filter and report by these
-                    items.
+                    Subscription Watch can help you filter and report by these items.
                   </Content>
                   <Content component={ContentVariants.p}>
                     Only roles available to your account are shown.
@@ -171,8 +164,8 @@ const ActivationKeyForm = (props) => {
               bodyContent={
                 <Content>
                   <Content component={ContentVariants.p}>
-                    Service Level Agreement (SLA) determines the level of
-                    support for systems registered with this activation key.
+                    Service Level Agreement (SLA) determines the level of support for systems
+                    registered with this activation key.
                   </Content>
                 </Content>
               }
@@ -197,12 +190,11 @@ const ActivationKeyForm = (props) => {
               bodyContent={
                 <Content>
                   <Content component={ContentVariants.p}>
-                    Usage is used to categorize systems by how they are meant to
-                    be used, and therefore supported.
+                    Usage is used to categorize systems by how they are meant to be used, and
+                    therefore supported.
                   </Content>
                   <Content component={ContentVariants.p}>
-                    Subscription Watch can help you filter and report by these
-                    items.
+                    Subscription Watch can help you filter and report by these items.
                   </Content>
                 </Content>
               }
@@ -243,7 +235,7 @@ ActivationKeyForm.propTypes = {
   submitForm: PropTypes.func.isRequired,
   isSuccess: PropTypes.bool,
   isError: PropTypes.bool,
-  activationKey: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
+  activationKey: PropTypes.oneOfType([PropTypes.object, PropTypes.bool])
 };
 
 export default ActivationKeyForm;

--- a/src/Components/Forms/ActivationKeysFormSelect.js
+++ b/src/Components/Forms/ActivationKeysFormSelect.js
@@ -18,7 +18,7 @@ const ActivationKeysFormSelect = (props) => {
     name,
     value,
     placeholderValue,
-    disableDefaultValues,
+    disableDefaultValues
   } = props;
   const [selected, setSelected] = useState('');
   const options = data.map((role) => {
@@ -62,7 +62,7 @@ ActivationKeysFormSelect.propTypes = {
   name: PropTypes.string,
   placeholderValue: PropTypes.string,
   value: PropTypes.string,
-  disableDefaultValues: PropTypes.bool,
+  disableDefaultValues: PropTypes.bool
 };
 
 export default ActivationKeysFormSelect;

--- a/src/Components/Forms/SystemPurposeForm.js
+++ b/src/Components/Forms/SystemPurposeForm.js
@@ -104,7 +104,7 @@ SystemPurposeForm.propTypes = {
   submitForm: PropTypes.func.isRequired,
   isSuccess: PropTypes.bool,
   isError: PropTypes.bool,
-  activationKey: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
+  activationKey: PropTypes.oneOfType([PropTypes.object, PropTypes.bool])
 };
 
 export default SystemPurposeForm;

--- a/src/Components/Forms/__tests__/ActivationKeyForm.test.js
+++ b/src/Components/Forms/__tests__/ActivationKeyForm.test.js
@@ -13,7 +13,7 @@ const ActivationKeyFormProps = {
   handleModalToggle,
   submitForm: submitForm,
   isSuccess: null,
-  isError: null,
+  isError: null
 };
 
 const props = { ...ActivationKeyFormProps };
@@ -27,8 +27,8 @@ describe('Activation Key Form', () => {
       data: {
         roles: ['role'],
         serviceLevel: ['serviceLevel'],
-        usage: ['usage'],
-      },
+        usage: ['usage']
+      }
     });
   });
 
@@ -36,7 +36,7 @@ describe('Activation Key Form', () => {
     const { container } = render(
       <QueryClientProvider client={queryClient}>
         <ActivationKeyForm {...props} />
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
     expect(container).toMatchSnapshot();
   });
@@ -46,7 +46,7 @@ describe('Activation Key Form', () => {
     const { container } = render(
       <QueryClientProvider client={queryClient}>
         <ActivationKeyForm {...props} />
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
     const nameInput = container.querySelector('#activation-key-name');
     fireEvent.change(nameInput, { target: { value: '!123' } });
@@ -62,7 +62,7 @@ describe('Activation Key Form', () => {
     const { container } = render(
       <QueryClientProvider client={queryClient}>
         <ActivationKeyForm {...props} />
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
     const validLength = Array(256).join('a');
     const invalidLength = Array(257).join('b');
@@ -80,16 +80,16 @@ describe('Activation Key Form', () => {
       name: 'test',
       usage: 'test',
       serviceLevel: 'test',
-      role: 'test',
+      role: 'test'
     };
     const props = {
       ...ActivationKeyFormProps,
-      activationKey: activationKey,
+      activationKey: activationKey
     };
     render(
       <QueryClientProvider client={queryClient}>
         <ActivationKeyForm {...props} />
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
     const submitButton = screen.getByTestId('activation-key-submit-button');
     expect(submitButton).toBeDisabled();
@@ -101,7 +101,7 @@ describe('Activation Key Form', () => {
     const { container } = render(
       <QueryClientProvider client={queryClient}>
         <ActivationKeyForm {...props} />
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
     const form = container.querySelector('#activation-key-form');
     const nameInput = container.querySelector('#activation-key-name');
@@ -116,7 +116,7 @@ describe('Activation Key Form', () => {
     render(
       <QueryClientProvider client={queryClient}>
         <ActivationKeyForm {...props} />
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
 
     expect(handleModalToggle).toHaveBeenCalledTimes(1);

--- a/src/Components/Modals/ActivationKeyWizard.js
+++ b/src/Components/Modals/ActivationKeyWizard.js
@@ -52,50 +52,27 @@ const nameValidator = (newName, keyNames) => {
 };
 const descriptionValidator = (description) => {
   const trimmedDescription = description.trim();
-  return (
-    description === '' ||
-    (trimmedDescription.length > 0 && trimmedDescription.length <= 255)
-  );
+  return description === '' || (trimmedDescription.length > 0 && trimmedDescription.length <= 255);
 };
 
-const ActivationKeyWizard = ({
-  isEditMode,
-  activationKey,
-  handleModalToggle,
-  isOpen,
-}) => {
+const ActivationKeyWizard = ({ isEditMode, activationKey, handleModalToggle, isOpen }) => {
   const queryClient = useQueryClient();
-  const {
-    mutate: createActivationKey,
-    isPending: createActivationKeyIsLoading,
-  } = useCreateActivationKey();
-  const {
-    mutate: updateActivationKey,
-    isPending: updateActivationKeyIsLoading,
-  } = useUpdateActivationKey();
-  const {
-    isLoading: attributesAreLoading,
-    error,
-    data,
-  } = useSystemPurposeAttributes();
-  const {
-    mutate: deleteAdditionalRepositories,
-    isPending: isDeleteAdditionalRepositoriesLoading,
-  } = useDeleteAdditionalRepositories();
-  const {
-    mutate: addAdditionalRepositories,
-    isPending: isAddAdditionRepositoriesLoading,
-  } = useAddAdditionalRepositories();
+  const { mutate: createActivationKey, isPending: createActivationKeyIsLoading } =
+    useCreateActivationKey();
+  const { mutate: updateActivationKey, isPending: updateActivationKeyIsLoading } =
+    useUpdateActivationKey();
+  const { isLoading: attributesAreLoading, error, data } = useSystemPurposeAttributes();
+  const { mutate: deleteAdditionalRepositories, isPending: isDeleteAdditionalRepositoriesLoading } =
+    useDeleteAdditionalRepositories();
+  const { mutate: addAdditionalRepositories, isPending: isAddAdditionRepositoriesLoading } =
+    useAddAdditionalRepositories();
   const { data: activationKeys } = useActivationKeys();
   const { addSuccessNotification, addErrorNotification } = useNotifications();
   const [name, setName] = useState('');
-  const [description, setDescription] = useState(
-    activationKey?.description || '',
-  );
+  const [description, setDescription] = useState(activationKey?.description || '');
   const [extendedReleaseProduct, setExtendedReleaseProduct] = useState('');
   const [extendedReleaseVersion, setExtendedReleaseVersion] = useState('');
-  const [extendedReleaseRepositories, setExtendedReleaseRepositories] =
-    useState([]);
+  const [extendedReleaseRepositories, setExtendedReleaseRepositories] = useState([]);
   const [role, setRole] = useState(activationKey?.role);
   const [sla, setSla] = useState(activationKey?.serviceLevel);
   const [usage, setUsage] = useState(activationKey?.usage);
@@ -103,9 +80,7 @@ const ActivationKeyWizard = ({
   const [shouldConfirmClose, setShouldConfirmClose] = useState(false);
   const [currentStep, setCurrentStep] = useState(0);
   const [workload, setWorkload] = useState(() =>
-    isEditMode && activationKey?.releaseVersion
-      ? 'Extended support releases'
-      : 'Latest release',
+    isEditMode && activationKey?.releaseVersion ? 'Extended support releases' : 'Latest release'
   );
   const [mutationError, setMutationError] = useState(false);
 
@@ -130,7 +105,7 @@ const ActivationKeyWizard = ({
   const {
     isLoading: isReleaseVersionsLoading,
     error: eusError,
-    data: releaseVersions,
+    data: releaseVersions
   } = useEusVersions();
   const [inferredReleaseProduct, setInferredReleaseProduct] = useState('');
   const [errorInferringProduct, setErrorInferringProduct] = useState(false);
@@ -155,11 +130,9 @@ const ActivationKeyWizard = ({
             (c) =>
               c.version == activationKey.releaseVersion &&
               c.repositories.every((repo) =>
-                activationKey.additionalRepositories.find(
-                  (has) => has.repositoryLabel == repo,
-                ),
-              ),
-          ),
+                activationKey.additionalRepositories.find((has) => has.repositoryLabel == repo)
+              )
+          )
         )?.name;
 
         if (!inferredReleaseProduct) {
@@ -169,13 +142,11 @@ const ActivationKeyWizard = ({
         }
       }
       setExtendedReleaseProduct(
-        (prev) => inferredReleaseProduct || prev || releaseVersions[0]?.name,
+        (prev) => inferredReleaseProduct || prev || releaseVersions[0]?.name
       );
       setExtendedReleaseVersion(
         (prev) =>
-          prev ||
-          activationKey?.releaseVersion ||
-          releaseVersions[0]?.configurations[0]?.version,
+          prev || activationKey?.releaseVersion || releaseVersions[0]?.configurations[0]?.version
       );
     } else {
       setExtendedReleaseProduct('');
@@ -190,17 +161,12 @@ const ActivationKeyWizard = ({
    * applicable repos
    */
   useEffect(() => {
-    if (
-      releaseVersions &&
-      workload.includes('Extended') &&
-      extendedReleaseProduct
-    ) {
+    if (releaseVersions && workload.includes('Extended') && extendedReleaseProduct) {
       setExtendedReleaseRepositories(
         releaseVersions
           .find((product) => extendedReleaseProduct == product.name)
-          .configurations.find(
-            (configuration) => extendedReleaseVersion == configuration.version,
-          ).repositories,
+          .configurations.find((configuration) => extendedReleaseVersion == configuration.version)
+          .repositories
       );
     } else {
       setExtendedReleaseRepositories([]);
@@ -211,7 +177,7 @@ const ActivationKeyWizard = ({
     queryClient.invalidateQueries({ queryKey: ['activation_keys'] });
     if (activationKey?.name) {
       queryClient.invalidateQueries({
-        queryKey: [`activation_key_${activationKey.name}`],
+        queryKey: [`activation_key_${activationKey.name}`]
       });
     }
     handleModalToggle();
@@ -238,28 +204,23 @@ const ActivationKeyWizard = ({
       serviceLevel: sla,
       usage,
       additionalRepositories:
-        workload.includes('Extended') && !isEditMode
-          ? extendedReleaseRepositories
-          : undefined,
-      releaseVersion: extendedReleaseVersion,
+        workload.includes('Extended') && !isEditMode ? extendedReleaseRepositories : undefined,
+      releaseVersion: extendedReleaseVersion
     };
 
     if (isEditMode) {
       // missing repos it should have
       const missing = extendedReleaseRepositories.filter((label) => {
         return (
-          activationKey.additionalRepositories.findIndex(
-            (cur) => cur.repositoryLabel == label,
-          ) == -1
+          activationKey.additionalRepositories.findIndex((cur) => cur.repositoryLabel == label) ==
+          -1
         );
       });
 
       // has repos it shouldn't have
       const extra = activationKey.additionalRepositories.filter((repo) => {
         return (
-          extendedReleaseRepositories.findIndex(
-            (label) => label == repo.repositoryLabel,
-          ) == -1
+          extendedReleaseRepositories.findIndex((label) => label == repo.repositoryLabel) == -1
         );
       });
 
@@ -268,7 +229,7 @@ const ActivationKeyWizard = ({
         deleteAdditionalRepositories(
           {
             name: activationKey.name,
-            payload: activationKey.additionalRepositories,
+            payload: activationKey.additionalRepositories
           },
           {
             onError: () => {
@@ -279,23 +240,19 @@ const ActivationKeyWizard = ({
                 addAdditionalRepositories(
                   {
                     keyName: activationKey.name,
-                    selectedRepositories: extendedReleaseRepositories.map(
-                      (r) => ({
-                        repositoryLabel: r,
-                      }),
-                    ),
+                    selectedRepositories: extendedReleaseRepositories.map((r) => ({
+                      repositoryLabel: r
+                    }))
                   },
                   {
                     onError: () => {
-                      addErrorNotification(
-                        'Error updating additional repositories',
-                      );
-                    },
-                  },
+                      addErrorNotification('Error updating additional repositories');
+                    }
+                  }
                 );
               }
-            },
-          },
+            }
+          }
         );
       }
     }
@@ -305,7 +262,7 @@ const ActivationKeyWizard = ({
         addSuccessNotification(
           isEditMode
             ? `Changes saved for activation key "${activationKey.name}"`
-            : `Activation key "${name}" created`,
+            : `Activation key "${name}" created`
         );
         setMutationError(false);
       },
@@ -313,10 +270,10 @@ const ActivationKeyWizard = ({
         addErrorNotification(
           isEditMode
             ? `Error updating activation key ${activationKey.name}.`
-            : 'Something went wrong.',
+            : 'Something went wrong.'
         );
         setMutationError(true);
-      },
+      }
     });
   };
 
@@ -338,10 +295,8 @@ const ActivationKeyWizard = ({
         />
       ),
       customFooter: {
-        isNextDisabled: isEditMode
-          ? !descriptionIsValid
-          : !nameIsValid || !descriptionIsValid,
-      },
+        isNextDisabled: isEditMode ? !descriptionIsValid : !nameIsValid || !descriptionIsValid
+      }
     },
     {
       name: 'Workload',
@@ -364,7 +319,7 @@ const ActivationKeyWizard = ({
           inferredReleaseProduct={inferredReleaseProduct}
         />
       ),
-      isDisabled: !isEditMode && !nameIsValid,
+      isDisabled: !isEditMode && !nameIsValid
     },
     {
       name: 'System purpose',
@@ -383,7 +338,7 @@ const ActivationKeyWizard = ({
           isError={error}
         />
       ),
-      isDisabled: !isEditMode && !nameIsValid,
+      isDisabled: !isEditMode && !nameIsValid
     },
     {
       name: 'Review',
@@ -397,17 +352,15 @@ const ActivationKeyWizard = ({
           role={role}
           sla={sla}
           usage={usage}
-          isLoading={
-            createActivationKeyIsLoading || updateActivationKeyIsLoading
-          }
+          isLoading={createActivationKeyIsLoading || updateActivationKeyIsLoading}
           extendedReleaseProduct={extendedReleaseProduct}
           extendedReleaseVersion={extendedReleaseVersion}
         />
       ),
       isDisabled: !isEditMode && !nameIsValid,
       customFooter: {
-        nextButtonText: isEditMode ? 'Update' : 'Create',
-      },
+        nextButtonText: isEditMode ? 'Update' : 'Create'
+      }
     },
     {
       name: 'Finish',
@@ -426,19 +379,15 @@ const ActivationKeyWizard = ({
         />
       ),
       customNav: <></>,
-      customFooter: <></>,
-    },
+      customFooter: <></>
+    }
   ];
 
   return (
     <Modal
       variant={isConfirmClose ? ModalVariant.small : ModalVariant.large}
       isOpen={isOpen}
-      aria-label={
-        isEditMode
-          ? 'Edit activation key wizard'
-          : 'Create activation key wizard'
-      }
+      aria-label={isEditMode ? 'Edit activation key wizard' : 'Create activation key wizard'}
       onClose={isConfirmClose ? undefined : confirmClose}
     >
       <ModalHeader
@@ -485,10 +434,7 @@ const ActivationKeyWizard = ({
       {isConfirmClose && confirmCloseBody}
       <ModalFooter>
         {isConfirmClose ? (
-          <ConfirmCloseFooter
-            onClose={onClose}
-            returnToWizard={returnToWizard}
-          />
+          <ConfirmCloseFooter onClose={onClose} returnToWizard={returnToWizard} />
         ) : undefined}
       </ModalFooter>
     </Modal>
@@ -497,7 +443,7 @@ const ActivationKeyWizard = ({
 
 ConfirmCloseFooter.propTypes = {
   onClose: PropTypes.func.isRequired,
-  returnToWizard: PropTypes.func.isRequired,
+  returnToWizard: PropTypes.func.isRequired
 };
 
 ActivationKeyWizard.propTypes = {
@@ -505,7 +451,7 @@ ActivationKeyWizard.propTypes = {
   activationKey: PropTypes.object,
   handleModalToggle: PropTypes.func.isRequired,
   isOpen: PropTypes.bool.isRequired,
-  CustomSuccessPage: PropTypes.node,
+  CustomSuccessPage: PropTypes.node
 };
 
 export default ActivationKeyWizard;

--- a/src/Components/Modals/AddAdditionalRepositoriesModal.js
+++ b/src/Components/Modals/AddAdditionalRepositoriesModal.js
@@ -19,7 +19,7 @@ const AddAdditionalRepositoriesModal = (props) => {
     isOpen,
     repositories,
     isLoading: additionalRepositoriesAreLoading,
-    error: additionalRepositoriesError,
+    error: additionalRepositoriesError
   } = props;
   const queryClient = useQueryClient();
   const [selectedRepositories, setSelectedRepositories] = useState([]);
@@ -36,23 +36,20 @@ const AddAdditionalRepositoriesModal = (props) => {
       {
         onSuccess: () => {
           queryClient.invalidateQueries({
-            queryKey: [`activation_key_${keyName}`],
+            queryKey: [`activation_key_${keyName}`]
           });
           queryClient.invalidateQueries({
-            queryKey: [`activation_key_${keyName}_available_repositories`],
+            queryKey: [`activation_key_${keyName}_available_repositories`]
           });
-          addSuccessNotification(
-            `Repositories have been added for '${keyName}'`,
-          );
+          addSuccessNotification(`Repositories have been added for '${keyName}'`);
           handleModalToggle();
         },
         onError: () => {
           addErrorNotification('Something went wrong', {
-            description:
-              'Your repositories could not be added. Please try again.',
+            description: 'Your repositories could not be added. Please try again.'
           });
-        },
-      },
+        }
+      }
     );
   };
 
@@ -69,27 +66,18 @@ const AddAdditionalRepositoriesModal = (props) => {
       >
         {isSubmitting ? 'Saving Changes' : 'Save Changes'}
       </Button>
-      <Button
-        key="cancel"
-        variant="link"
-        onClick={handleModalToggle}
-        isDisabled={isSubmitting}
-      >
+      <Button key="cancel" variant="link" onClick={handleModalToggle} isDisabled={isSubmitting}>
         Cancel
       </Button>
     </ActionGroup>
   );
 
-  const onClose =
-    isSubmitting || additionalRepositoriesError ? null : handleModalToggle;
+  const onClose = isSubmitting || additionalRepositoriesError ? null : handleModalToggle;
 
   return (
     <React.Fragment>
       <Modal variant={ModalVariant.large} isOpen={isOpen} onClose={onClose}>
-        <ModalHeader
-          title="Add repositories"
-          description={editAdditionalRepositoriesDescription}
-        />
+        <ModalHeader title="Add repositories" description={editAdditionalRepositoriesDescription} />
         <ModalBody>
           <AddAdditionalRepositoriesTable
             keyName={keyName}
@@ -114,7 +102,7 @@ AddAdditionalRepositoriesModal.propTypes = {
   repositories: propTypes.array,
   isLoading: propTypes.bool,
   error: propTypes.bool,
-  buttonState: propTypes.bool,
+  buttonState: propTypes.bool
 };
 
 export default AddAdditionalRepositoriesModal;

--- a/src/Components/Modals/DeleteActivationKeyConfirmationModal.js
+++ b/src/Components/Modals/DeleteActivationKeyConfirmationModal.js
@@ -22,7 +22,7 @@ const DeleteActivationKeyConfirmationModal = (props) => {
     mutate(name, {
       onSuccess: (_data, name) => {
         queryClient.setQueryData(['activation_keys'], (oldData) =>
-          oldData.filter((entry) => entry.name != name),
+          oldData.filter((entry) => entry.name != name)
         );
         addSuccessNotification(`Activation key ${name} deleted`);
         handleModalToggle(true);
@@ -30,7 +30,7 @@ const DeleteActivationKeyConfirmationModal = (props) => {
       onError: () => {
         addErrorNotification('Something went wrong. Please try again');
         handleModalToggle();
-      },
+      }
     });
     mutate;
   };
@@ -45,15 +45,14 @@ const DeleteActivationKeyConfirmationModal = (props) => {
     </Button>,
     <Button key="cancel" variant="link" onClick={handleModalToggle}>
       Cancel
-    </Button>,
+    </Button>
   ];
 
   const title = (
     <>
       <Content>
         <Content component={ContentVariants.h2}>
-          <ExclamationTriangleIcon size="md" color="#F0AB00" /> Delete
-          activation key?
+          <ExclamationTriangleIcon size="md" color="#F0AB00" /> Delete activation key?
         </Content>
       </Content>
     </>
@@ -65,8 +64,7 @@ const DeleteActivationKeyConfirmationModal = (props) => {
       return (
         <Content>
           <Content component={ContentVariants.p}>
-            <b>{name}</b> will no longer be available for use. This operation
-            cannot be undone.
+            <b>{name}</b> will no longer be available for use. This operation cannot be undone.
           </Content>
         </Content>
       );
@@ -89,7 +87,7 @@ const DeleteActivationKeyConfirmationModal = (props) => {
 DeleteActivationKeyConfirmationModal.propTypes = {
   isOpen: propTypes.bool.isRequired,
   handleModalToggle: propTypes.func.isRequired,
-  name: propTypes.string.Required,
+  name: propTypes.string.Required
 };
 
 export default DeleteActivationKeyConfirmationModal;

--- a/src/Components/Modals/DeleteAdditionalRepositoriesModal.js
+++ b/src/Components/Modals/DeleteAdditionalRepositoriesModal.js
@@ -12,44 +12,33 @@ import { useQueryClient } from '@tanstack/react-query';
 import useDeleteAdditionalRepositories from '../../hooks/useDeleteAdditionalRepositories';
 
 const DeleteAdditionalRepositoriesModal = (props) => {
-  const {
-    isOpen,
-    handleModalToggle,
-    name,
-    repositoryNameToDelete,
-    repositoryLabelToDelete,
-  } = props;
+  const { isOpen, handleModalToggle, name, repositoryNameToDelete, repositoryLabelToDelete } =
+    props;
   const { addSuccessNotification, addErrorNotification } = useNotifications();
   const { mutate, isLoading } = useDeleteAdditionalRepositories();
   const queryClient = useQueryClient();
 
-  const deleteAdditionalRepositories = (
-    name,
-    repositoryNameToDelete,
-    repositoryLabelToDelete,
-  ) => {
+  const deleteAdditionalRepositories = (name, repositoryNameToDelete, repositoryLabelToDelete) => {
     const payload = [
       {
         repositoryLabel: repositoryLabelToDelete,
-        repositoryName: repositoryNameToDelete,
-      },
+        repositoryName: repositoryNameToDelete
+      }
     ];
 
     mutate(
       { name, payload },
       {
         onSuccess: (_data, queryName) => {
-          addSuccessNotification(
-            `Additional repository ${repositoryNameToDelete} deleted`,
-          );
+          addSuccessNotification(`Additional repository ${repositoryNameToDelete} deleted`);
           queryClient.invalidateQueries({ queryKey: [queryName] });
           handleModalToggle();
         },
         onError: () => {
           addErrorNotification('Something went wrong. Please try again');
           handleModalToggle();
-        },
-      },
+        }
+      }
     );
   };
 
@@ -59,25 +48,16 @@ const DeleteAdditionalRepositoriesModal = (props) => {
       variant="danger"
       isLoading={isLoading}
       onClick={() =>
-        deleteAdditionalRepositories(
-          name,
-          repositoryNameToDelete,
-          repositoryLabelToDelete,
-        )
+        deleteAdditionalRepositories(name, repositoryNameToDelete, repositoryLabelToDelete)
       }
       isDisabled={isLoading}
       spinnerAriaValueText="Removing repository"
     >
       {isLoading ? 'Removing repository' : 'Remove repository'}
     </Button>,
-    <Button
-      key="cancel"
-      variant="link"
-      onClick={handleModalToggle}
-      isDisabled={isLoading}
-    >
+    <Button key="cancel" variant="link" onClick={handleModalToggle} isDisabled={isLoading}>
       Cancel
-    </Button>,
+    </Button>
   ];
 
   const title = (
@@ -95,8 +75,8 @@ const DeleteAdditionalRepositoriesModal = (props) => {
     <>
       <Content>
         <Content component={ContentVariants.p}>
-          <b>{repositoryNameToDelete}</b> will no longer be enabled when
-          registering with this activation key.
+          <b>{repositoryNameToDelete}</b> will no longer be enabled when registering with this
+          activation key.
         </Content>
       </Content>
     </>
@@ -121,7 +101,7 @@ DeleteAdditionalRepositoriesModal.propTypes = {
   handleModalToggle: propTypes.func.isRequired,
   repositoryNameToDelete: propTypes.string.isRequired,
   repositoryLabelToDelete: propTypes.string.isRequired,
-  name: propTypes.string.isRequired,
+  name: propTypes.string.isRequired
 };
 
 export default DeleteAdditionalRepositoriesModal;

--- a/src/Components/Modals/__tests__/ActivationKeyWizard.test.js
+++ b/src/Components/Modals/__tests__/ActivationKeyWizard.test.js
@@ -16,7 +16,7 @@ const queryClient = new QueryClient();
 const mutate = jest.fn();
 useCreateActivationKey.mockReturnValue({
   mutate,
-  error: false,
+  error: false
 });
 useEusVersions.mockReturnValue({});
 useReleaseVersions.mockReturnValue({});
@@ -24,7 +24,7 @@ useReleaseVersions.mockReturnValue({});
 jest.mock('uuid', () => ({
   __esModule: true,
   ...jest.requireActual('uuid'),
-  v4: jest.fn(() => '11111111-1111-1111-1111-111111111111'),
+  v4: jest.fn(() => '11111111-1111-1111-1111-111111111111')
 }));
 
 describe('Create Activation Key Wizard', () => {
@@ -34,7 +34,7 @@ describe('Create Activation Key Wizard', () => {
       render(
         <QueryClientProvider client={queryClient}>
           <ActivationKeyWizard handleModalToggle={() => {}} isOpen={true} />
-        </QueryClientProvider>,
+        </QueryClientProvider>
       );
       for (let i = 1; i < page; i++) {
         const nextStepBtn = screen.getByText(i < 4 ? 'Next' : 'Create');
@@ -48,11 +48,9 @@ describe('Create Activation Key Wizard', () => {
     const { container } = render(
       <QueryClientProvider client={queryClient}>
         <ActivationKeyWizard handleModalToggle={() => {}} isOpen={true} />
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
-    fireEvent.click(
-      container.nextSibling.querySelector('.pf-v6-c-modal-box__close'),
-    );
+    fireEvent.click(container.nextSibling.querySelector('.pf-v6-c-modal-box__close'));
     expect(document.body).toMatchSnapshot();
   });
 
@@ -60,14 +58,12 @@ describe('Create Activation Key Wizard', () => {
     const { container } = render(
       <QueryClientProvider client={queryClient}>
         <ActivationKeyWizard handleModalToggle={() => {}} isOpen={true} />
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
 
     const nextStepBtn = screen.getByText('Next');
     fireEvent.click(nextStepBtn);
-    fireEvent.click(
-      container.nextSibling.querySelector('.pf-v6-c-modal-box__close'),
-    );
+    fireEvent.click(container.nextSibling.querySelector('.pf-v6-c-modal-box__close'));
     expect(document.body).toMatchSnapshot();
   });
 
@@ -75,7 +71,7 @@ describe('Create Activation Key Wizard', () => {
     render(
       <QueryClientProvider client={queryClient}>
         <ActivationKeyWizard handleModalToggle={() => {}} isOpen={true} />
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
     for (let i = 1; i < 5; i++) {
       const nextStepBtn = screen.getByText(i < 4 ? 'Next' : 'Create');

--- a/src/Components/Modals/__tests__/AddAdditionalRepositoriesModal.test.js
+++ b/src/Components/Modals/__tests__/AddAdditionalRepositoriesModal.test.js
@@ -10,12 +10,12 @@ describe('Add Additional Repositories Modal', () => {
     const props = {
       handleModalToggle: jest.fn(),
       isOpen: true,
-      repositories: [],
+      repositories: []
     };
     render(
       <QueryClientProvider client={queryClient}>
         <AddAdditionalRepositoriesModal {...props} />
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
     expect(screen.getByText('Add repositories')).toBeInTheDocument();
     expect(screen.getByText('Add repositories')).toBeInTheDocument();

--- a/src/Components/Modals/__tests__/DeleteActivationKeyConfirmationModal.test.js
+++ b/src/Components/Modals/__tests__/DeleteActivationKeyConfirmationModal.test.js
@@ -11,12 +11,12 @@ describe('Delete Activation Key Confirmation Modal', () => {
     const props = {
       handleModalToggle: jest.fn(),
       isOpen: true,
-      name: activationKeyName,
+      name: activationKeyName
     };
     render(
       <QueryClientProvider client={queryClient}>
         <DeleteActivationKeyConfirmationModal {...props} />
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
     expect(screen.getByText(activationKeyName)).toBeInTheDocument();
     expect(screen.getByText('Delete activation key?')).toBeInTheDocument();

--- a/src/Components/NoAccessPopover/NoAccessPopover.js
+++ b/src/Components/NoAccessPopover/NoAccessPopover.js
@@ -5,9 +5,7 @@ import propTypes from 'prop-types';
 const NoAccessPopover = ({ content: Button }) => {
   return (
     <React.Fragment>
-      <Tooltip
-        content={<div>For editing access, contact your administrator.</div>}
-      >
+      <Tooltip content={<div>For editing access, contact your administrator.</div>}>
         <div className="pf-v6-u-display-inline-block">
           <Button />
         </div>
@@ -17,7 +15,7 @@ const NoAccessPopover = ({ content: Button }) => {
 };
 
 NoAccessPopover.propTypes = {
-  content: propTypes.elementType.isRequired,
+  content: propTypes.elementType.isRequired
 };
 
 export default NoAccessPopover;

--- a/src/Components/Notifications/__tests__/Notificaions.test.js
+++ b/src/Components/Notifications/__tests__/Notificaions.test.js
@@ -11,8 +11,8 @@ describe('Notifications', () => {
       notifications: [
         { message: 'Some stuff went well!', variant: 'success', key: '123' },
         { message: 'Some other stuff did not.', variant: 'danger', key: '456' },
-        { message: 'And this happened.', variant: 'info', key: '789' },
-      ],
+        { message: 'And this happened.', variant: 'info', key: '789' }
+      ]
     });
     render(<Notifications />);
     expect(document.body).toMatchSnapshot();
@@ -21,10 +21,8 @@ describe('Notifications', () => {
   it('calls the remove notifications method on click of the X', () => {
     const mockRemoveNotification = jest.fn();
     useNotifications.mockReturnValue({
-      notifications: [
-        { message: 'Some stuff went well!', variant: 'success', key: '123' },
-      ],
-      removeNotification: mockRemoveNotification,
+      notifications: [{ message: 'Some stuff went well!', variant: 'success', key: '123' }],
+      removeNotification: mockRemoveNotification
     });
     const { getByTestId } = render(<Notifications />);
     fireEvent.click(getByTestId('notification-close-btn-0'));
@@ -41,10 +39,10 @@ describe('Notifications', () => {
           message: 'Some stuff went well!',
           variant: 'success',
           key: '123',
-          downloadHref: 'foo.com',
-        },
+          downloadHref: 'foo.com'
+        }
       ],
-      removeNotification: mockRemoveNotification,
+      removeNotification: mockRemoveNotification
     });
     const { getByTestId } = render(<Notifications />);
     fireEvent.click(getByTestId('notification-close-btn-0'));

--- a/src/Components/Pages/NameAndDescriptionPage.js
+++ b/src/Components/Pages/NameAndDescriptionPage.js
@@ -11,7 +11,7 @@ const NameAndDescriptionPage = ({
   description,
   setDescription,
   descriptionIsValid,
-  isNameDisabled,
+  isNameDisabled
 }) => {
   return (
     <div className="pf-l-grid pf-m-gutter">
@@ -46,6 +46,6 @@ NameAndDescriptionPage.propTypes = {
   description: PropTypes.string,
   setDescription: PropTypes.func.isRequired,
   descriptionIsValid: PropTypes.bool.isRequired,
-  isNameDisabled: PropTypes.bool.isRequired,
+  isNameDisabled: PropTypes.bool.isRequired
 };
 export default NameAndDescriptionPage;

--- a/src/Components/Pages/ReviewActivationKeyPage.js
+++ b/src/Components/Pages/ReviewActivationKeyPage.js
@@ -20,7 +20,7 @@ const ReviewActivationKeyPage = ({
   isLoading,
   activationKey,
   extendedReleaseProduct,
-  extendedReleaseVersion,
+  extendedReleaseVersion
 }) => {
   if (isLoading) return <Loading />;
 
@@ -30,12 +30,12 @@ const ReviewActivationKeyPage = ({
     {
       term: 'Name',
       original: activationKey?.name,
-      updated: name || 'Not Defined',
+      updated: name || 'Not Defined'
     },
     {
       term: 'Description',
       original: activationKey?.description || 'Not Defined',
-      updated: description || 'Not Defined',
+      updated: description || 'Not Defined'
     },
     {
       term: 'Workload',
@@ -43,39 +43,39 @@ const ReviewActivationKeyPage = ({
         isEditMode && activationKey?.releaseVersion
           ? 'Extended support releases'
           : 'Latest release',
-      updated: workload || 'Not Defined',
-    },
+      updated: workload || 'Not Defined'
+    }
   ];
   if (workload === 'Extended support releases') {
     rows.push(
       {
         term: '',
         original: activationKey?.releaseProduct || 'Not Defined',
-        updated: extendedReleaseProduct || 'Not Defined',
+        updated: extendedReleaseProduct || 'Not Defined'
       },
       {
         term: '',
         original: activationKey?.releaseVersion || 'Not Defined',
-        updated: extendedReleaseVersion || 'Not Defined',
-      },
+        updated: extendedReleaseVersion || 'Not Defined'
+      }
     );
   }
   rows.push(
     {
       term: 'Role',
       original: activationKey?.role || 'Not Defined',
-      updated: role || 'Not Defined',
+      updated: role || 'Not Defined'
     },
     {
       term: 'Service level agreement (SLA)',
       original: activationKey?.serviceLevel || 'Not Defined',
-      updated: sla || 'Not Defined',
+      updated: sla || 'Not Defined'
     },
     {
       term: 'Usage',
       original: activationKey?.usage || 'Not Defined',
-      updated: usage || 'Not Defined',
-    },
+      updated: usage || 'Not Defined'
+    }
   );
 
   return (
@@ -91,14 +91,10 @@ const ReviewActivationKeyPage = ({
       <DescriptionList isHorizontal>
         {rows.map((row, index) => (
           <DescriptionListGroup key={index}>
-            <DescriptionListTerm style={{ flexBasis: '35%' }}>
-              {row.term}
-            </DescriptionListTerm>
+            <DescriptionListTerm style={{ flexBasis: '35%' }}>{row.term}</DescriptionListTerm>
             <DescriptionListDescription>
               {isEditMode ? (
-                <div
-                  style={{ display: 'flex', justifyContent: 'space-between' }}
-                >
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
                   <span style={{ flexBasis: '45%' }}>{row.original}</span>
                   <span style={{ flexBasis: '45%' }}>{row.updated}</span>
                 </div>
@@ -123,7 +119,7 @@ ReviewActivationKeyPage.propTypes = {
     serviceLevel: PropTypes.string,
     usage: PropTypes.string,
     releaseVersion: PropTypes.string,
-    releaseProduct: PropTypes.string,
+    releaseProduct: PropTypes.string
   }),
   name: PropTypes.string.isRequired,
   description: PropTypes.string,
@@ -133,6 +129,6 @@ ReviewActivationKeyPage.propTypes = {
   usage: PropTypes.string.isRequired,
   isLoading: PropTypes.bool.isRequired,
   extendedReleaseProduct: PropTypes.string,
-  extendedReleaseVersion: PropTypes.string,
+  extendedReleaseVersion: PropTypes.string
 };
 export default ReviewActivationKeyPage;

--- a/src/Components/Pages/SetNamePage.js
+++ b/src/Components/Pages/SetNamePage.js
@@ -13,13 +13,11 @@ import { validate as isUUID, v4 as uuid } from 'uuid';
 import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
 
 const SetNamePage = ({ name, setName, nameIsValid, isNameDisabled }) => {
-  const [enableValidationFeedback, setEnableValidationFeedback] =
-    useState(false);
+  const [enableValidationFeedback, setEnableValidationFeedback] = useState(false);
 
   const helperText =
     'Your activation key name must be unique and must contain only numbers, letters, underscores, and hyphens.';
-  const validated =
-    nameIsValid || !enableValidationFeedback ? 'default' : 'error';
+  const validated = nameIsValid || !enableValidationFeedback ? 'default' : 'error';
   const helperTextInvalid = `Name requirements have not been met. ${helperText}`;
 
   useEffect(() => {
@@ -59,14 +57,9 @@ const SetNamePage = ({ name, setName, nameIsValid, isNameDisabled }) => {
               </HelperTextItem>
               {!isUUID(name) && !isNameDisabled && (
                 <HelperTextItem variant="error">
-                  Custom activation key names may be guessable and insecure. We
-                  suggest using the default name provided or provide a long,
-                  unguessable value.{' '}
-                  <Button
-                    variant="link"
-                    isInline
-                    onClick={() => setName(uuid())}
-                  >
+                  Custom activation key names may be guessable and insecure. We suggest using the
+                  default name provided or provide a long, unguessable value.{' '}
+                  <Button variant="link" isInline onClick={() => setName(uuid())}>
                     Click here
                   </Button>{' '}
                   to regenerate a secure name.
@@ -84,7 +77,7 @@ SetNamePage.propTypes = {
   name: PropTypes.string.isRequired,
   setName: PropTypes.func.isRequired,
   nameIsValid: PropTypes.bool.isRequired,
-  isNameDisabled: PropTypes.bool.isRequired,
+  isNameDisabled: PropTypes.bool.isRequired
 };
 
 export default SetNamePage;

--- a/src/Components/Pages/SetSystemPurposePage.js
+++ b/src/Components/Pages/SetSystemPurposePage.js
@@ -20,7 +20,7 @@ const SetSystemPurposePage = ({
   setUsage,
   data,
   isLoading,
-  isError,
+  isError
 }) => {
   useEffect(() => {
     setRole(activationKey?.role || '');
@@ -35,11 +35,9 @@ const SetSystemPurposePage = ({
     </>
   );
   Options.propTypes = {
-    options: PropTypes.array.isRequired,
+    options: PropTypes.array.isRequired
   };
-  const Placeholder = () => (
-    <FormSelectOption label="Not defined" isPlaceholder />
-  );
+  const Placeholder = () => <FormSelectOption label="Not defined" isPlaceholder />;
   if (isLoading) return <Loading />;
   if (isError) return null;
   return (
@@ -48,18 +46,13 @@ const SetSystemPurposePage = ({
         {isEditMode ? 'Edit system purpose' : 'Select system purpose'}{' '}
       </Title>
       <Content component={ContentVariants.p} className="pf-v6-u-mb-xl">
-        System purpose values are used by the subscriptions service to help
-        filter and identify hosts. Setting values for these attributes is an
-        optional step, but doing so ensures that subscriptions reporting
-        accurately reflects the system. Only those values available to your
+        System purpose values are used by the subscriptions service to help filter and identify
+        hosts. Setting values for these attributes is an optional step, but doing so ensures that
+        subscriptions reporting accurately reflects the system. Only those values available to your
         account are shown.
       </Content>
       <Form>
-        <FormGroup
-          label="Role"
-          className="pf-v6-u-mb-sm"
-          fieldId="activation-key-role"
-        >
+        <FormGroup label="Role" className="pf-v6-u-mb-sm" fieldId="activation-key-role">
           <FormSelect
             onChange={(_event, value) => setRole(value)}
             value={role}
@@ -83,11 +76,7 @@ const SetSystemPurposePage = ({
             <Placeholder />
           </FormSelect>
         </FormGroup>
-        <FormGroup
-          label="Usage"
-          className="pf-v6-u-mb-sm"
-          fieldId="activation-key-usage"
-        >
+        <FormGroup label="Usage" className="pf-v6-u-mb-sm" fieldId="activation-key-usage">
           <FormSelect
             onChange={(_event, value) => setUsage(value)}
             value={usage}
@@ -114,9 +103,9 @@ SetSystemPurposePage.propTypes = {
   data: PropTypes.shape({
     roles: PropTypes.array.isRequired,
     serviceLevel: PropTypes.array,
-    usage: PropTypes.array,
+    usage: PropTypes.array
   }).isRequired,
   isLoading: PropTypes.bool.isRequired,
-  isError: PropTypes.bool,
+  isError: PropTypes.bool
 };
 export default SetSystemPurposePage;

--- a/src/Components/Pages/SetWorkLoadPage.js
+++ b/src/Components/Pages/SetWorkLoadPage.js
@@ -26,7 +26,7 @@ const SetWorkloadPage = ({
   error,
   releaseVersions,
   errorInferringProduct,
-  inferredReleaseProduct,
+  inferredReleaseProduct
 }) => {
   return (
     <>
@@ -34,9 +34,8 @@ const SetWorkloadPage = ({
         {isEditMode ? 'Edit Workload' : 'Select Workload'}
       </Title>
       <Content component={ContentVariants.p} className="pf-v6-u-mb-xl">
-        Choose a workload option to associate an appropriate selection of
-        repositories to the activation key. Repositories can be edited on the
-        activation key detail page.
+        Choose a workload option to associate an appropriate selection of repositories to the
+        activation key. Repositories can be edited on the activation key detail page.
       </Content>
       {!isLoading ? (
         workloadOptions.map((wl, i) => {
@@ -51,14 +50,10 @@ const SetWorkloadPage = ({
                   'Activation key will use the latest RHEL release'
                 ) : (
                   <Content>
-                    <Content
-                      className="pf-v6-u-color-light-100"
-                      component={ContentVariants.small}
-                    >
-                      Activation key can be version locked to a specific version
-                      of RHEL. You can only version lock an activation key to a
-                      RHEL release that has the option of Extended Update
-                      Support (EUS). For more information, please refer to:
+                    <Content className="pf-v6-u-color-light-100" component={ContentVariants.small}>
+                      Activation key can be version locked to a specific version of RHEL. You can
+                      only version lock an activation key to a RHEL release that has the option of
+                      Extended Update Support (EUS). For more information, please refer to:
                       <a
                         href="https://access.redhat.com/articles/rhel-eus#c9"
                         target="_blank"
@@ -96,34 +91,20 @@ const SetWorkloadPage = ({
               id="product"
             >
               {releaseVersions.map((product, i) => {
-                return (
-                  <FormSelectOption
-                    key={i}
-                    value={product.name}
-                    label={product.name}
-                  />
-                );
+                return <FormSelectOption key={i} value={product.name} label={product.name} />;
               })}
             </FormSelect>
             {errorInferringProduct && (
-              <Content
-                component="small"
-                className="pf-v6-u-text-color-status-danger"
-              >
-                Unable to infer product based on current additional
-                repositories. &quot;{extendedReleaseProduct}&quot; has been
-                selected by default.
+              <Content component="small" className="pf-v6-u-text-color-status-danger">
+                Unable to infer product based on current additional repositories. &quot;
+                {extendedReleaseProduct}&quot; has been selected by default.
               </Content>
             )}
           </FormGroup>
           <FormGroup label="Version">
             <FormSelect
               onChange={(_event, v) => setExtendedReleaseVersion(v)}
-              value={
-                extendedReleaseVersion ||
-                activationKey?.releaseVersion ||
-                'Not Defined'
-              }
+              value={extendedReleaseVersion || activationKey?.releaseVersion || 'Not Defined'}
               id="version"
             >
               {releaseVersions
@@ -141,18 +122,12 @@ const SetWorkloadPage = ({
       )}
       {!isLoading &&
         isEditMode &&
-        !(
-          activationKey?.releaseVersion == undefined &&
-          extendedReleaseVersion == ''
-        ) &&
+        !(activationKey?.releaseVersion == undefined && extendedReleaseVersion == '') &&
         (activationKey?.releaseVersion != extendedReleaseVersion ||
           inferredReleaseProduct != extendedReleaseProduct) && (
-          <Content
-            component="small"
-            className="pf-v6-u-text-color-status-danger"
-          >
-            Editing the release version or product may remove all existing
-            additional repositories from this key.
+          <Content component="small" className="pf-v6-u-text-color-status-danger">
+            Editing the release version or product may remove all existing additional repositories
+            from this key.
           </Content>
         )}
     </>
@@ -174,6 +149,6 @@ SetWorkloadPage.propTypes = {
   error: PropTypes.object.isRequired,
   releaseVersions: PropTypes.arrayOf(PropTypes.object).isRequired,
   errorInferringProduct: PropTypes.bool.isRequired,
-  inferredReleaseProduct: PropTypes.string.isRequired,
+  inferredReleaseProduct: PropTypes.string.isRequired
 };
 export default SetWorkloadPage;

--- a/src/Components/Pages/SuccessPage.js
+++ b/src/Components/Pages/SuccessPage.js
@@ -3,7 +3,7 @@ import { Bullseye } from '@patternfly/react-core/dist/dynamic/layouts/Bullseye';
 import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
 import {
   EmptyState,
-  EmptyStateStatus,
+  EmptyStateStatus
 } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
 import { EmptyStateBody } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
 
@@ -19,9 +19,7 @@ const SuccessPage = ({ isLoading, name, onClose, isEditMode, isError }) => {
   const navigate = useInsightsNavigate();
   const { goToPrevStep } = useWizardContext();
 
-  const titleText = isEditMode
-    ? 'Edit activation key'
-    : 'Activation key created';
+  const titleText = isEditMode ? 'Edit activation key' : 'Activation key created';
   const bodyText = isEditMode
     ? `${name} has been edited and is now ready for use. Click View activation key to view the change(s) in the details page.`
     : `${name} is now available for use. Click "View activation key" to edit settings or add repositories.`;
@@ -33,11 +31,7 @@ const SuccessPage = ({ isLoading, name, onClose, isEditMode, isError }) => {
   const content = isLoading ? (
     <Spinner />
   ) : (
-    <EmptyState
-      headingLevel="h4"
-      status={EmptyStateStatus.success}
-      titleText={titleText}
-    >
+    <EmptyState headingLevel="h4" status={EmptyStateStatus.success} titleText={titleText}>
       <EmptyStateBody>{bodyText}</EmptyStateBody>
       <EmptyStateFooter>
         <Button
@@ -65,7 +59,7 @@ SuccessPage.propTypes = {
   name: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
   isEditMode: PropTypes.bool.isRequired,
-  isError: PropTypes.bool.isRequired,
+  isError: PropTypes.bool.isRequired
 };
 
 export default SuccessPage;

--- a/src/Components/WriteOnlyButton/WriteOnlyButton.js
+++ b/src/Components/WriteOnlyButton/WriteOnlyButton.js
@@ -6,12 +6,7 @@ import { Tooltip } from '@patternfly/react-core/dist/dynamic/components/Tooltip'
 import { Relation, useHasRelation } from '../../hooks/useHasRelation';
 
 const WriteOnlyButton = (props) => {
-  const {
-    children,
-    enabledTooltip,
-    disabledTooltip = 'Disabled',
-    ...buttonProps
-  } = props;
+  const { children, enabledTooltip, disabledTooltip = 'Disabled', ...buttonProps } = props;
 
   const { has: canWriteActivationKeys } = useHasRelation(Relation.KEYS_EDIT);
 
@@ -24,11 +19,7 @@ const WriteOnlyButton = (props) => {
       {isDisabled ? (
         <NoAccessPopover
           content={() => (
-            <Tooltip
-              position="top"
-              content={disabledTooltip}
-              trigger="mouseenter"
-            >
+            <Tooltip position="top" content={disabledTooltip} trigger="mouseenter">
               <Button {...buttonProps} isDisabled>
                 {children}
               </Button>
@@ -38,11 +29,7 @@ const WriteOnlyButton = (props) => {
       ) : (
         <>
           {showEnabledTooltip && (
-            <Tooltip
-              position="top"
-              content={enabledTooltip}
-              trigger="mouseenter"
-            >
+            <Tooltip position="top" content={enabledTooltip} trigger="mouseenter">
               <Button {...buttonProps}>{children}</Button>
             </Tooltip>
           )}
@@ -56,7 +43,7 @@ const WriteOnlyButton = (props) => {
 WriteOnlyButton.propTypes = {
   children: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   enabledTooltip: PropTypes.string,
-  disabledTooltip: PropTypes.string,
+  disabledTooltip: PropTypes.string
 };
 
 export default WriteOnlyButton;

--- a/src/Components/shared/breadcrumbs.js
+++ b/src/Components/shared/breadcrumbs.js
@@ -19,14 +19,14 @@ const Breadcrumbs = (breadcrumbs) => {
           </BreadcrumbItem>
         ) : (
           '/'
-        ),
+        )
       )}
     </Breadcrumb>
   ) : null;
 };
 
 Breadcrumbs.propTypes = {
-  breadcrumbs: PropTypes.object,
+  breadcrumbs: PropTypes.object
 };
 
 export default Breadcrumbs;

--- a/src/Modules/CreateActivationKeyWizardWithContext.js
+++ b/src/Modules/CreateActivationKeyWizardWithContext.js
@@ -10,9 +10,9 @@ const queryClient = new QueryClient({
       retryDelay: 10 * 1000,
       staleTime: Infinity,
       refetchOnWindowFocus: false,
-      refetchOnMount: false,
-    },
-  },
+      refetchOnMount: false
+    }
+  }
 });
 
 const CreateActivationKeyWizardWithContext = (props) => {

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -45,7 +45,7 @@ const AppRoutes = () => {
 };
 
 SuspenseWrapped.propTypes = {
-  children: PropTypes.element.isRequired,
+  children: PropTypes.element.isRequired
 };
 
 export default AppRoutes;

--- a/src/__mocks__/tabbable.js
+++ b/src/__mocks__/tabbable.js
@@ -2,14 +2,10 @@ const lib = jest.requireActual('tabbable');
 
 const pf = {
   ...lib,
-  tabbable: (node, options) =>
-    lib.tabbable(node, { ...options, displayCheck: 'none' }),
-  focusable: (node, options) =>
-    lib.focusable(node, { ...options, displayCheck: 'none' }),
-  isFocusable: (node, options) =>
-    lib.isFocusable(node, { ...options, displayCheck: 'none' }),
-  isTabbable: (node, options) =>
-    lib.isTabbable(node, { ...options, displayCheck: 'none' }),
+  tabbable: (node, options) => lib.tabbable(node, { ...options, displayCheck: 'none' }),
+  focusable: (node, options) => lib.focusable(node, { ...options, displayCheck: 'none' }),
+  isFocusable: (node, options) => lib.isFocusable(node, { ...options, displayCheck: 'none' }),
+  isTabbable: (node, options) => lib.isTabbable(node, { ...options, displayCheck: 'none' })
 };
 
 module.exports = pf;

--- a/src/contexts/NotificationProvider.js
+++ b/src/contexts/NotificationProvider.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 const NotificationContext = React.createContext({
   notifications: [],
   addNotification: () => null,
-  removeNotification: () => null,
+  removeNotification: () => null
 });
 
 const NotificationProvider = ({ children }) => {
@@ -19,13 +19,11 @@ const NotificationProvider = ({ children }) => {
       message: message,
       key: notificationKey,
       timeout: options?.hasTimeout ?? true,
-      description: options?.description,
+      description: options?.description
     };
 
     if (options && options.alertLinkText && options.alertLinkHref) {
-      const linkAttributes = options.alertLinkIsDownload
-        ? { download: '' }
-        : {};
+      const linkAttributes = options.alertLinkIsDownload ? { download: '' } : {};
       const alertLink = (
         <>
           <AlertActionLink>
@@ -46,17 +44,13 @@ const NotificationProvider = ({ children }) => {
   };
 
   const addNotification = (variant, message, options) => {
-    const newNotificationProps = buildNotificationProps(
-      variant,
-      message,
-      options,
-    );
+    const newNotificationProps = buildNotificationProps(variant, message, options);
 
     let newNotifications = [...notifications, { ...newNotificationProps }];
 
     if (options && options.keyOfAlertToReplace) {
       newNotifications = newNotifications.filter(
-        (notification) => notification.key !== options.keyOfAlertToReplace,
+        (notification) => notification.key !== options.keyOfAlertToReplace
       );
     }
 
@@ -65,9 +59,7 @@ const NotificationProvider = ({ children }) => {
   };
 
   const removeNotification = (key) => {
-    setNotifications(
-      notifications.filter((notification) => notification.key !== key),
-    );
+    setNotifications(notifications.filter((notification) => notification.key !== key));
   };
 
   const contextValue = {
@@ -75,18 +67,16 @@ const NotificationProvider = ({ children }) => {
     addNotification: (variant, message, options) => {
       return addNotification(variant, message, options);
     },
-    removeNotification: (key) => removeNotification(key),
+    removeNotification: (key) => removeNotification(key)
   };
 
   return (
-    <NotificationContext.Provider value={contextValue}>
-      {children}
-    </NotificationContext.Provider>
+    <NotificationContext.Provider value={contextValue}>{children}</NotificationContext.Provider>
   );
 };
 
 NotificationProvider.propTypes = {
-  children: PropTypes.node,
+  children: PropTypes.node
 };
 
 export { NotificationContext, NotificationProvider as default };

--- a/src/hooks/__tests__/useActivationKey.test.js
+++ b/src/hooks/__tests__/useActivationKey.test.js
@@ -12,14 +12,14 @@ describe('useActivationKey', () => {
         name: 'A',
         role: 'role',
         sla: 'sla',
-        usage: 'usage',
-      },
+        usage: 'usage'
+      }
     ];
 
     fetch.mockResponseOnce(JSON.stringify({ body: [...keyData] }));
 
     const { result } = renderHook(() => useActivationKey('A'), {
-      wrapper: createQueryWrapper(),
+      wrapper: createQueryWrapper()
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));

--- a/src/hooks/__tests__/useActivationKeys.test.js
+++ b/src/hooks/__tests__/useActivationKeys.test.js
@@ -12,14 +12,14 @@ describe('useActivationKeys', () => {
         name: 'A',
         role: 'role',
         sla: 'sla',
-        usage: 'usage',
-      },
+        usage: 'usage'
+      }
     ];
 
     fetch.mockResponseOnce(JSON.stringify({ body: [...keyData] }));
 
     const { result } = renderHook(() => useActivationKeys(), {
-      wrapper: createQueryWrapper(),
+      wrapper: createQueryWrapper()
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));

--- a/src/hooks/__tests__/useAddAdditionalRepositories.test.js
+++ b/src/hooks/__tests__/useAddAdditionalRepositories.test.js
@@ -7,22 +7,15 @@ enableFetchMocks();
 
 describe('useAddAdditionalRepositories', () => {
   it('adds additional repository to activationKey', async () => {
-    fetch.mockResponseOnce(
-      JSON.stringify({ body: [{ repositoryLabel: 'repository-A' }] }),
-    );
+    fetch.mockResponseOnce(JSON.stringify({ body: [{ repositoryLabel: 'repository-A' }] }));
     const keyParams = {
-      selectedRepositories: [
-        { repositoryLabel: 'repository-A', repositoryName: 'repository A' },
-      ],
-      keyName: 'A',
+      selectedRepositories: [{ repositoryLabel: 'repository-A', repositoryName: 'repository A' }],
+      keyName: 'A'
     };
 
-    const { result } = renderHook(
-      () => useAddAdditionalRepositories(keyParams.keyName),
-      {
-        wrapper: createQueryWrapper(),
-      },
-    );
+    const { result } = renderHook(() => useAddAdditionalRepositories(keyParams.keyName), {
+      wrapper: createQueryWrapper()
+    });
 
     await act(async () => {
       result.current.mutate(keyParams);

--- a/src/hooks/__tests__/useAvailableRepositories.test.js
+++ b/src/hooks/__tests__/useAvailableRepositories.test.js
@@ -17,7 +17,7 @@ describe('useAvailableRepositories', () => {
 
       useQuery.mockReturnValueOnce({
         isLoading: false,
-        data: repositories,
+        data: repositories
       });
 
       const result = useAvailableRepositories(keyName);
@@ -30,7 +30,7 @@ describe('useAvailableRepositories', () => {
   test('should handle error during fetch correctly', async () => {
     useQuery.mockReturnValueOnce({
       isLoading: false,
-      error: new Error('Fetch failed'),
+      error: new Error('Fetch failed')
     });
 
     const result = useAvailableRepositories(keyName);

--- a/src/hooks/__tests__/useCreateActivationKey.test.js
+++ b/src/hooks/__tests__/useCreateActivationKey.test.js
@@ -13,10 +13,10 @@ describe('useActivationKeys', () => {
       description: 'description',
       role: 'role',
       serviceLevel: 'sla',
-      usage: 'usage',
+      usage: 'usage'
     };
     const { result } = renderHook(() => useCreateActivationKey(), {
-      wrapper: createQueryWrapper(),
+      wrapper: createQueryWrapper()
     });
     await act(async () => {
       result.current.mutate(keyParams);

--- a/src/hooks/__tests__/useHasRelation.test.js
+++ b/src/hooks/__tests__/useHasRelation.test.js
@@ -1,6 +1,6 @@
 import {
   // fetchDefaultWorkspace, TODO: Add back once the sdk is fixed
-  useAccessCheckContext,
+  useAccessCheckContext
 } from '@project-kessel/react-kessel-access-check';
 import { checkSelf } from '@project-kessel/react-kessel-access-check/core/api-client';
 import { renderHook, waitFor } from '@testing-library/react';
@@ -31,7 +31,7 @@ describe('useHasRelation hook', () => {
     checkSelf.mockReturnValue({ allowed: 'ALLOWED_TRUE' });
 
     const { result } = renderHook(() => useHasRelation(Relation.KEYS_VIEW), {
-      wrapper: createQueryWrapper(),
+      wrapper: createQueryWrapper()
     });
 
     await waitFor(() => expect(result.current.has).toBe(true));
@@ -41,7 +41,7 @@ describe('useHasRelation hook', () => {
     checkSelf.mockReturnValue({ allowed: 'ALLOWED_TRUE' });
 
     const { result } = renderHook(() => useHasRelation(Relation.KEYS_VIEW), {
-      wrapper: createQueryWrapper(),
+      wrapper: createQueryWrapper()
     });
 
     expect(result.current.isLoading).toBe(true);
@@ -52,7 +52,7 @@ describe('useHasRelation hook', () => {
     checkSelf.mockReturnValue({ allowed: 'ALLOWED_FALSE' });
 
     const { result } = renderHook(() => useHasRelation(Relation.KEYS_VIEW), {
-      wrapper: createQueryWrapper(),
+      wrapper: createQueryWrapper()
     });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -65,7 +65,7 @@ describe('useHasRelation hook', () => {
     });
 
     const { result } = renderHook(() => useHasRelation(Relation.KEYS_VIEW), {
-      wrapper: createQueryWrapper(),
+      wrapper: createQueryWrapper()
     });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -77,7 +77,7 @@ describe('useHasRelation hook', () => {
       checkSelf.mockReturnValue({});
 
       const { result } = renderHook(() => useHasRelation(Relation.KEYS_VIEW), {
-        wrapper: createQueryWrapper(),
+        wrapper: createQueryWrapper()
       });
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -88,7 +88,7 @@ describe('useHasRelation hook', () => {
       checkSelf.mockReturnValue({ allowed: 'A_WEIRD_VALUE' });
 
       const { result } = renderHook(() => useHasRelation(Relation.KEYS_VIEW), {
-        wrapper: createQueryWrapper(),
+        wrapper: createQueryWrapper()
       });
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -100,7 +100,7 @@ describe('useHasRelation hook', () => {
       fetchDefaultWorkspace.mockRejectedValue('oops!');
 
       const { result } = renderHook(() => useHasRelation(Relation.KEYS_VIEW), {
-        wrapper: createQueryWrapper(),
+        wrapper: createQueryWrapper()
       });
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));

--- a/src/hooks/__tests__/useUpdateActivationKey.test.js
+++ b/src/hooks/__tests__/useUpdateActivationKey.test.js
@@ -12,10 +12,10 @@ describe('useUpdateActivationKey', () => {
       name: 'A',
       role: 'role',
       serviceLevel: 'sla',
-      usage: 'usage',
+      usage: 'usage'
     };
     const { result } = renderHook(() => useUpdateActivationKey(), {
-      wrapper: createQueryWrapper(),
+      wrapper: createQueryWrapper()
     });
     await act(async () => {
       result.current.mutate(keyParams);

--- a/src/hooks/__tests__/useUser.test.js
+++ b/src/hooks/__tests__/useUser.test.js
@@ -6,20 +6,20 @@ import { useAuthenticateUser } from '../../utils/platformServices';
 jest.mock('../../utils/platformServices.js');
 
 useAuthenticateUser.mockResolvedValue({
-  data: { identity: { account_number: '1', internal: { org_id: 1 } } },
+  data: { identity: { account_number: '1', internal: { org_id: 1 } } }
 });
 
 describe('useUser hook', () => {
   it('gets the user data and permissions', async () => {
     const { result } = renderHook(() => useUser(), {
-      wrapper: createQueryWrapper(),
+      wrapper: createQueryWrapper()
     });
 
     await waitFor(() =>
       expect(result.current.data).toEqual({
         accountNumber: '1',
-        orgId: 1,
-      }),
+        orgId: 1
+      })
     );
   });
 });

--- a/src/hooks/useActivationKey.js
+++ b/src/hooks/useActivationKey.js
@@ -7,7 +7,7 @@ const fetchActivationKeyData = (token) => async (keyName) => {
   }
 
   const response = await fetch(`/api/rhsm/v2/activation_keys/${keyName}`, {
-    headers: { Authorization: `Bearer ${await token}` },
+    headers: { Authorization: `Bearer ${await token}` }
   });
 
   const activationKeysData = await response.json();
@@ -25,7 +25,7 @@ const useActivationKey = (keyName) => {
 
   return useQuery({
     queryKey: [`activation_key_${keyName}`],
-    queryFn: () => getActivationKey(chrome?.auth?.getToken())(keyName),
+    queryFn: () => getActivationKey(chrome?.auth?.getToken())(keyName)
   });
 };
 

--- a/src/hooks/useActivationKeys.js
+++ b/src/hooks/useActivationKeys.js
@@ -3,7 +3,7 @@ import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const fetchActivationKeysData = (token) => async () => {
   const response = await fetch('/api/rhsm/v2/activation_keys', {
-    headers: { Authorization: `Bearer ${await token}` },
+    headers: { Authorization: `Bearer ${await token}` }
   });
 
   const activationKeysData = await response.json();
@@ -21,7 +21,7 @@ const useActivationKeys = () => {
 
   return useQuery({
     queryKey: ['activation_keys'],
-    queryFn: getActivationKeys(chrome?.auth?.getToken()),
+    queryFn: getActivationKeys(chrome?.auth?.getToken())
   });
 };
 

--- a/src/hooks/useAddAdditionalRepositories.js
+++ b/src/hooks/useAddAdditionalRepositories.js
@@ -5,30 +5,25 @@ const additionalRepositoriesMutation = (token) => async (data) => {
   const { keyName, selectedRepositories } = data;
 
   const additionalRepositoryLabels = selectedRepositories.map(
-    (repository) => repository.repositoryLabel,
+    (repository) => repository.repositoryLabel
   );
 
   if (!keyName) {
-    throw new Error(
-      `Activation Key name must be provided to add additional repositiories.`,
-    );
+    throw new Error(`Activation Key name must be provided to add additional repositiories.`);
   }
 
-  const response = await fetch(
-    `/api/rhsm/v2/activation_keys/${keyName}/additional_repositories`,
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${await token}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(
-        additionalRepositoryLabels.map((label) => ({
-          repositoryLabel: label,
-        })),
-      ),
+  const response = await fetch(`/api/rhsm/v2/activation_keys/${keyName}/additional_repositories`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${await token}`,
+      'Content-Type': 'application/json'
     },
-  );
+    body: JSON.stringify(
+      additionalRepositoryLabels.map((label) => ({
+        repositoryLabel: label
+      }))
+    )
+  });
 
   if (Math.floor(response.status / 100) !== 2) {
     throw new Error();
@@ -41,7 +36,7 @@ const useAddAdditionalRepositories = () => {
   const chrome = useChrome();
 
   return useMutation({
-    mutationFn: additionalRepositoriesMutation(chrome?.auth?.getToken()),
+    mutationFn: additionalRepositoriesMutation(chrome?.auth?.getToken())
   });
 };
 

--- a/src/hooks/useAvailableRepositories.js
+++ b/src/hooks/useAvailableRepositories.js
@@ -8,7 +8,7 @@ const fetchAdditionalRepositories = async (
   offset = 0,
   filters = {},
   sortBy = '',
-  sortDirection = '',
+  sortDirection = ''
 ) => {
   if (!keyName) {
     return false;
@@ -36,8 +36,8 @@ const fetchAdditionalRepositories = async (
   const response = await fetch(
     `/api/rhsm/v2/activation_keys/${keyName}/available_repositories?default=Disabled&limit=${limit}&offset=${offset}&${filterQuery}&sort_by=${sortBy}&sort_direction=${sortDirection}`,
     {
-      headers: { Authorization: `Bearer ${await token}` },
-    },
+      headers: { Authorization: `Bearer ${await token}` }
+    }
   );
 
   if (!response.ok) {
@@ -48,14 +48,7 @@ const fetchAdditionalRepositories = async (
   return repositoriesData;
 };
 
-const useAvailableRepositories = (
-  keyName,
-  page,
-  pageSize,
-  filters,
-  sortBy,
-  sortDirection,
-) => {
+const useAvailableRepositories = (keyName, page, pageSize, filters, sortBy, sortDirection) => {
   const chrome = useChrome();
   const token = chrome?.auth?.getToken();
 
@@ -66,7 +59,7 @@ const useAvailableRepositories = (
       pageSize,
       filters,
       sortBy,
-      sortDirection,
+      sortDirection
     ],
     queryFn: () =>
       fetchAdditionalRepositories(
@@ -76,23 +69,15 @@ const useAvailableRepositories = (
         (page - 1) * pageSize,
         filters,
         sortBy,
-        sortDirection,
-      ),
+        sortDirection
+      )
   });
 };
 
 const usePrefetchAvailableRepositoriesNextPage = () => {
   const chrome = useChrome();
 
-  return async (
-    queryClient,
-    keyName,
-    page,
-    pageSize,
-    filters,
-    sortBy,
-    sortDirection,
-  ) => {
+  return async (queryClient, keyName, page, pageSize, filters, sortBy, sortDirection) => {
     const token = chrome?.auth?.getToken();
 
     queryClient.prefetchQuery({
@@ -102,7 +87,7 @@ const usePrefetchAvailableRepositoriesNextPage = () => {
         pageSize,
         filters,
         sortBy,
-        sortDirection,
+        sortDirection
       ],
       queryFn: () =>
         fetchAdditionalRepositories(
@@ -112,13 +97,10 @@ const usePrefetchAvailableRepositoriesNextPage = () => {
           (page - 1) * pageSize,
           filters,
           sortBy,
-          sortDirection,
-        ),
+          sortDirection
+        )
     });
   };
 };
 
-export {
-  useAvailableRepositories as default,
-  usePrefetchAvailableRepositoriesNextPage,
-};
+export { useAvailableRepositories as default, usePrefetchAvailableRepositoriesNextPage };

--- a/src/hooks/useCreateActivationKey.js
+++ b/src/hooks/useCreateActivationKey.js
@@ -2,15 +2,8 @@ import { useMutation } from '@tanstack/react-query';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const activationKeyMutation = (token) => async (data) => {
-  const {
-    name,
-    description,
-    role,
-    serviceLevel,
-    usage,
-    additionalRepositories,
-    releaseVersion,
-  } = data;
+  const { name, description, role, serviceLevel, usage, additionalRepositories, releaseVersion } =
+    data;
 
   const body = {
     name,
@@ -18,26 +11,26 @@ const activationKeyMutation = (token) => async (data) => {
     role,
     serviceLevel,
     usage,
-    ...(releaseVersion ? { releaseVersion } : {}),
+    ...(releaseVersion ? { releaseVersion } : {})
   };
 
   if (additionalRepositories) {
-    body.additionalRepositories = additionalRepositories.map(
-      (repositoryLabel) => ({ repositoryLabel }),
-    );
+    body.additionalRepositories = additionalRepositories.map((repositoryLabel) => ({
+      repositoryLabel
+    }));
   }
 
   const response = await fetch('/api/rhsm/v2/activation_keys', {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${await token}`,
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/json'
     },
-    body: JSON.stringify(body),
+    body: JSON.stringify(body)
   });
   if (!response.ok) {
     throw new Error(
-      `Status Code ${response.status}.  Error creating activation key: ${response.statusText}.`,
+      `Status Code ${response.status}.  Error creating activation key: ${response.statusText}.`
     );
   }
   return response.json();
@@ -47,7 +40,7 @@ const useCreateActivationKey = () => {
   const chrome = useChrome();
 
   return useMutation({
-    mutationFn: activationKeyMutation(chrome?.auth?.getToken()),
+    mutationFn: activationKeyMutation(chrome?.auth?.getToken())
   });
 };
 

--- a/src/hooks/useDeleteActivationKey.js
+++ b/src/hooks/useDeleteActivationKey.js
@@ -6,12 +6,12 @@ const deleteActivationKeyMutation = (token) => async (name) => {
     method: 'DELETE',
     headers: {
       Authorization: `Bearer ${await token}`,
-      'Content-Type': 'application/json',
-    },
+      'Content-Type': 'application/json'
+    }
   });
   if (!response.ok) {
     throw new Error(
-      `Status Code ${response.status}.  Error deleting activation key: ${response.statusText}.`,
+      `Status Code ${response.status}.  Error deleting activation key: ${response.statusText}.`
     );
   }
 };
@@ -20,7 +20,7 @@ const useDeleteActivationKey = () => {
   const chrome = useChrome();
 
   return useMutation({
-    mutationFn: deleteActivationKeyMutation(chrome?.auth?.getToken()),
+    mutationFn: deleteActivationKeyMutation(chrome?.auth?.getToken())
   });
 };
 

--- a/src/hooks/useDeleteAdditionalRepositories.js
+++ b/src/hooks/useDeleteAdditionalRepositories.js
@@ -4,21 +4,18 @@ import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 const deleteAdditionalRepositoriesMutation =
   (token) =>
   async ({ name, payload }) => {
-    const response = await fetch(
-      `/api/rhsm/v2/activation_keys/${name}/additional_repositories`,
-      {
-        method: 'DELETE',
-        headers: {
-          Authorization: `Bearer ${await token}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(payload),
+    const response = await fetch(`/api/rhsm/v2/activation_keys/${name}/additional_repositories`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${await token}`,
+        'Content-Type': 'application/json'
       },
-    );
+      body: JSON.stringify(payload)
+    });
 
     if (!response.ok) {
       throw new Error(
-        `Status Code ${response.status}. Error deleting additional repository: ${response.statusText}.`,
+        `Status Code ${response.status}. Error deleting additional repository: ${response.statusText}.`
       );
     }
   };
@@ -27,7 +24,7 @@ const useDeleteAdditionalRepositories = () => {
   const chrome = useChrome();
 
   return useMutation({
-    mutationFn: deleteAdditionalRepositoriesMutation(chrome?.auth?.getToken()),
+    mutationFn: deleteAdditionalRepositoriesMutation(chrome?.auth?.getToken())
   });
 };
 

--- a/src/hooks/useEusVersions.js
+++ b/src/hooks/useEusVersions.js
@@ -2,12 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const fetchEusVersions = (token) => async () => {
-  const response = await fetch(
-    '/api/rhsm/v2/products/RHEL/extended-update-support-products',
-    {
-      headers: { Authorization: `Bearer ${await token}` },
-    },
-  );
+  const response = await fetch('/api/rhsm/v2/products/RHEL/extended-update-support-products', {
+    headers: { Authorization: `Bearer ${await token}` }
+  });
 
   if (!response.ok) {
     return Promise.reject(response.status);
@@ -29,7 +26,7 @@ const useEusVersions = () => {
         return true;
       }
       return false;
-    },
+    }
   });
 };
 

--- a/src/hooks/useHasRelation.js
+++ b/src/hooks/useHasRelation.js
@@ -1,6 +1,6 @@
 import {
   // fetchDefaultWorkspace, TODO: Add back once the sdk is fixed
-  useAccessCheckContext,
+  useAccessCheckContext
 } from '@project-kessel/react-kessel-access-check';
 import { checkSelf } from '@project-kessel/react-kessel-access-check/core/api-client';
 import { useQuery } from '@tanstack/react-query';
@@ -11,14 +11,14 @@ const QUERY_STALE_TIME = 5 * 60 * 1000;
 
 export const Relation = {
   KEYS_VIEW: 'config_manager_activation_keys_view',
-  KEYS_EDIT: 'config_manager_activation_keys_edit',
+  KEYS_EDIT: 'config_manager_activation_keys_edit'
 };
 
 const useDefaultWorkspace = () =>
   useQuery({
     queryKey: ['rbac', 'default-workspace'],
     queryFn: async () => await fetchDefaultWorkspace(window.location.origin),
-    staleTime: QUERY_STALE_TIME,
+    staleTime: QUERY_STALE_TIME
   });
 
 /**
@@ -29,7 +29,7 @@ export const useHasRelation = (relation) => {
   const {
     data: defaultWorkspace,
     isLoading: defaultWorkspaceIsLoading,
-    isError: defaultWorkspaceIsError,
+    isError: defaultWorkspaceIsError
   } = useDefaultWorkspace();
 
   const { data: has, isLoading: accessCheckIsLoading } = useQuery({
@@ -42,18 +42,18 @@ export const useHasRelation = (relation) => {
             resource: {
               id: defaultWorkspace.id,
               type: 'workspace',
-              reporter: { type: 'rbac' },
-            },
+              reporter: { type: 'rbac' }
+            }
           })
         ).allowed === 'ALLOWED_TRUE'
       );
     },
     enabled: !defaultWorkspaceIsLoading && !defaultWorkspaceIsError,
-    staleTime: QUERY_STALE_TIME,
+    staleTime: QUERY_STALE_TIME
   });
 
   return {
     has: !!has,
-    isLoading: accessCheckIsLoading || defaultWorkspaceIsLoading,
+    isLoading: accessCheckIsLoading || defaultWorkspaceIsLoading
   };
 };

--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -2,8 +2,7 @@ import { useContext } from 'react';
 import { NotificationContext } from '../contexts/NotificationProvider';
 
 const useNotifications = () => {
-  const { notifications, addNotification, removeNotification } =
-    useContext(NotificationContext);
+  const { notifications, addNotification, removeNotification } = useContext(NotificationContext);
 
   const addSuccessNotification = (message, options) => {
     return addNotification('success', message, options);
@@ -22,7 +21,7 @@ const useNotifications = () => {
     addSuccessNotification,
     addErrorNotification,
     addInfoNotification,
-    removeNotification,
+    removeNotification
   };
 };
 

--- a/src/hooks/useReleaseVersions.js
+++ b/src/hooks/useReleaseVersions.js
@@ -2,12 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const fetchReleaseVersions = (token) => async () => {
-  const response = await fetch(
-    `/api/rhsm/v2/products/RHEL/extended-update-support-versions`,
-    {
-      headers: { Authorization: `Bearer ${await token}` },
-    },
-  );
+  const response = await fetch(`/api/rhsm/v2/products/RHEL/extended-update-support-versions`, {
+    headers: { Authorization: `Bearer ${await token}` }
+  });
 
   const releaseVersions = await response.json();
 
@@ -24,7 +21,7 @@ const useReleaseVersions = (keyName) => {
 
   return useQuery({
     queryKey: [`activation_key_${keyName}`],
-    queryFn: () => getReleaseVersions(chrome?.auth?.getToken())(keyName),
+    queryFn: () => getReleaseVersions(chrome?.auth?.getToken())(keyName)
   });
 };
 

--- a/src/hooks/useSystemPurposeAttributes.js
+++ b/src/hooks/useSystemPurposeAttributes.js
@@ -2,12 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const fetchSystemPurposeAttributes = (token) => async () => {
-  const response = await fetch(
-    '/api/rhsm/v2/organization?include=system_purpose_attributes',
-    {
-      headers: { Authorization: `Bearer ${await token}` },
-    },
-  );
+  const response = await fetch('/api/rhsm/v2/organization?include=system_purpose_attributes', {
+    headers: { Authorization: `Bearer ${await token}` }
+  });
 
   const responseData = await response.json();
 
@@ -24,7 +21,7 @@ const useSystemPurposeAttributes = () => {
 
   return useQuery({
     queryKey: ['organization_system_purpose_attributes'],
-    queryFn: getSystemPurposeAttributes(chrome?.auth?.getToken()),
+    queryFn: getSystemPurposeAttributes(chrome?.auth?.getToken())
   });
 };
 

--- a/src/hooks/useUpdateActivationKey.js
+++ b/src/hooks/useUpdateActivationKey.js
@@ -8,19 +8,19 @@ const activationKeyMutation = (token) => async (data) => {
     method: 'PUT',
     headers: {
       Authorization: `Bearer ${await token}`,
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/json'
     },
     body: JSON.stringify({
       role,
       serviceLevel,
       usage,
       releaseVersion,
-      description,
-    }),
+      description
+    })
   });
   if (!response.ok) {
     throw new Error(
-      `Status Code ${response.status}.  Error updating activation key: ${response.statusText}.`,
+      `Status Code ${response.status}.  Error updating activation key: ${response.statusText}.`
     );
   }
 
@@ -30,7 +30,7 @@ const activationKeyMutation = (token) => async (data) => {
 const useUpdateActivationKey = () => {
   const chrome = useChrome();
   return useMutation({
-    mutationFn: activationKeyMutation(chrome.auth.getToken()),
+    mutationFn: activationKeyMutation(chrome.auth.getToken())
   });
 };
 

--- a/src/hooks/useUser.js
+++ b/src/hooks/useUser.js
@@ -9,8 +9,8 @@ const useUser = () => {
     queryFn: () =>
       Promise.all([authenticateUser]).then(([userStatus]) => ({
         accountNumber: userStatus?.data.identity?.account_number,
-        orgId: userStatus?.data.identity?.internal?.org_id,
-      })),
+        orgId: userStatus?.data.identity?.internal?.org_id
+      }))
   });
 };
 

--- a/src/utils/__tests__/dateHelpers.tests.js
+++ b/src/utils/__tests__/dateHelpers.tests.js
@@ -7,13 +7,13 @@ jest.mock('uuid', () => {
 });
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useLocation: () => ({ pathname: '/connector/test-key' }),
+  useLocation: () => ({ pathname: '/connector/test-key' })
 }));
 
 jest.mock(
   '@redhat-cloud-services/frontend-components/Unavailable',
   // eslint-disable-next-line react/display-name
-  () => () => <div>Unavailable</div>,
+  () => () => <div>Unavailable</div>
 );
 
 describe('printDate', () => {
@@ -39,7 +39,7 @@ describe('sortActivationKeys', () => {
   const mockData = [
     { name: 'Key1', updatedAt: '2023-10-21T10:30:00Z' },
     { name: 'Key2', updatedAt: '2023-10-19T10:30:00Z' },
-    { name: 'Key3', updatedAt: '2023-10-20T10:30:00Z' },
+    { name: 'Key3', updatedAt: '2023-10-20T10:30:00Z' }
   ];
   const mockColumnNames = ['name', 'role', 'SLA', 'Usage', 'updatedAt'];
 

--- a/src/utils/__tests__/platformServices.tests.js
+++ b/src/utils/__tests__/platformServices.tests.js
@@ -3,9 +3,7 @@ import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { renderHook, waitFor } from '@testing-library/react';
 import { createQueryWrapper } from '../../utils/testHelpers';
 
-jest.mock('@redhat-cloud-services/frontend-components/useChrome', () =>
-  jest.fn(),
-);
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => jest.fn());
 
 describe('Authenticate User method', () => {
   it('should return a promise with user data', async () => {
@@ -16,15 +14,15 @@ describe('Authenticate User method', () => {
             identity: {
               account_number: 1,
               internal: {
-                org_id: 1,
-              },
-            },
-          }),
-      },
+                org_id: 1
+              }
+            }
+          })
+      }
     }));
 
     const { result } = renderHook(() => useAuthenticateUser(), {
-      wrapper: createQueryWrapper(),
+      wrapper: createQueryWrapper()
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -33,23 +31,23 @@ describe('Authenticate User method', () => {
       identity: {
         account_number: 1,
         internal: {
-          org_id: 1,
-        },
-      },
+          org_id: 1
+        }
+      }
     });
   });
 
   it('should throw an error if rejected', async () => {
     useChrome.mockImplementation(() => ({
       auth: {
-        getUser: () => Promise.reject(new Error('Error getting user')),
-      },
+        getUser: () => Promise.reject(new Error('Error getting user'))
+      }
     }));
 
     expect(() =>
       renderHook(() => useAuthenticateUser(), {
-        wrapper: createQueryWrapper(),
-      }).toThrow(Error('Error getting user')),
+        wrapper: createQueryWrapper()
+      }).toThrow(Error('Error getting user'))
     );
   });
 });

--- a/src/utils/fetchDefaultWorkspace.js
+++ b/src/utils/fetchDefaultWorkspace.js
@@ -8,8 +8,8 @@ export const fetchDefaultWorkspace = async (rbacBaseEndpoint) => {
   const response = await fetch(url, {
     method: 'GET',
     headers: {
-      'Content-type': 'application/json',
-    },
+      'Content-type': 'application/json'
+    }
   });
 
   if (!response.ok) {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,10 +1,6 @@
-export const pluralize = (count, str, fallback) =>
-  count > 1 ? fallback || str + 's' : str;
+export const pluralize = (count, str, fallback) => (count > 1 ? fallback || str + 's' : str);
 
-export const downloadFile = (
-  data,
-  filename = `${new Date().toISOString()}`,
-) => {
+export const downloadFile = (data, filename = `${new Date().toISOString()}`) => {
   const type = 'data:text/plain;charset=utf-8,';
   const blob = new Blob([data], { type });
   const link = document.createElement('a');

--- a/src/utils/platformServices.js
+++ b/src/utils/platformServices.js
@@ -12,7 +12,7 @@ const useAuthenticateUser = () => {
       } catch (e) {
         throw new Error(`Error authenticating user: ${e.message}`);
       }
-    },
+    }
   });
 };
 

--- a/src/utils/testHelpers.js
+++ b/src/utils/testHelpers.js
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const createQueryWrapper = () => {
   const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+    defaultOptions: { queries: { retry: false } }
   });
   const wrapper = ({ children }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>


### PR DESCRIPTION
This adds a claudemd for ai-assisted development, as well as updates this formatting/linting rules to match our other apps. The linter and formatted have been run, introducing all these formatting changes

The one caveat is that this app is not on typescript yet, so linting rules will be slightly different to reflect that

## Summary by Sourcery

Align formatting and linting across the activation keys UI and add AI assistance documentation.

Enhancements:
- Reformat JavaScript source, tests, hooks, and configuration files to a consistent Prettier/ESLint style.
- Tighten prop type definitions and minor validation logic for components and hooks without altering behavior.
- Simplify various React component structures and hook usages for readability while preserving functionality.

Build:
- Add Prettier as a dev dependency and configure it via a new .prettierrc file.

Documentation:
- Add a CLAUDE.md file documenting project architecture, conventions, and AI usage guidelines.

Tests:
- Normalize test code formatting and modernize some test helpers and mocks for consistency.